### PR TITLE
Refactor user context and Apollo call

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 
 import { GlobalStyle } from './ui-components/GlobalStyle'
@@ -12,40 +12,44 @@ import Post from './screens/Post';
 import Proposals from './screens/Proposals';
 import SignupForm from './screens/SignupForm';
 import VerifyEmail from './screens/VerifyEmail';
+import Apollo from './components/Apollo';
 
 const App = () => {
+
 	return (
 		<>
 			<GlobalStyle />
 			<Router>
 				<UserDetailsProvider>
-					<MenuBar/>
-					<Switch>
-						<Route exact path="/">
-							<Home/>
-						</Route>
-						<Route path="/discussions">
-							<Discussions/>
-						</Route>
-						<Route path="/login">
-							<LoginForm/>
-						</Route>
-						<Route path="/post/create" >
-							<CreatePost/>
-						</Route>
-						<Route exact path="/post/:id" >
-							<Post/>
-						</Route>
-						<Route path="/proposals" >
-							<Proposals/>
-						</Route>
-						<Route path="/signup">
-							<SignupForm/>
-						</Route>
-						<Route path="/verify-email/:token">
-							<VerifyEmail/>
-						</Route>
-					</Switch>
+					<Apollo>
+						<MenuBar/>
+						<Switch>
+							<Route exact path="/">
+								<Home/>
+							</Route>
+							<Route path="/discussions">
+								<Discussions/>
+							</Route>
+							<Route path="/login">
+								<LoginForm/>
+							</Route>
+							<Route path="/post/create" >
+								<CreatePost/>
+							</Route>
+							<Route exact path="/post/:id" >
+								<Post/>
+							</Route>
+							<Route path="/proposals" >
+								<Proposals/>
+							</Route>
+							<Route path="/signup">
+								<SignupForm/>
+							</Route>
+							<Route path="/verify-email/:token">
+								<VerifyEmail/>
+							</Route>
+						</Switch>
+					</Apollo>
 				</UserDetailsProvider>
 			</Router>
 		</>

--- a/front-end/src/components/Apollo.tsx
+++ b/front-end/src/components/Apollo.tsx
@@ -1,0 +1,106 @@
+import { ApolloProvider } from '@apollo/react-hooks';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+import { ApolloClient } from 'apollo-client';
+import { ApolloLink } from 'apollo-link';
+import { setContext } from 'apollo-link-context';
+import { HttpLink } from 'apollo-link-http';
+import { TokenRefreshLink } from 'apollo-link-token-refresh';
+import React from 'react';
+
+import {
+	isLocalStorageTokenValidOrUndefined,
+	getLocalStorageToken,
+	getRefreshedToken,
+	storeLocalStorageToken,
+	deleteLocalStorageToken
+} from '../services/auth.service';
+import { Get_Refresh_TokenQueryResult } from '../generated/auth-graphql';
+
+const setAuthorizationLink = setContext(() => {
+	const token = getLocalStorageToken()
+	if (token) {
+		return { headers: { authorization: `Bearer ${token}` } }
+	} else {
+		return null
+	}
+});
+
+const httpLink = new HttpLink({
+	uri: process.env.REACT_APP_HASURA_GRAPHQL_URL
+});
+
+// const currentUser = useContext(UserDetailsContext);
+// const publicKey = process.env.REACT_APP_JWT_PUBLIC_KEY;
+
+const handleFetch = (accessToken : string) => {
+	// try {
+	// 	const tokenPayload = accessToken && publicKey && jwt.verify(accessToken, publicKey) as JWTPayploadType;
+	storeLocalStorageToken(accessToken)
+	// 	if (tokenPayload && tokenPayload.sub && tokenPayload.name ){
+	// 		const id = tokenPayload.sub
+	// 		const username =  tokenPayload.name
+
+	// 		if (id && username){
+	// 			setUserDetailsContextState((prevState) => {
+	// 				return {
+	// 					...prevState,
+	// 					id,
+	// 					username
+	// 				}
+	// 			})
+	// 		}
+	// 	}
+	// } catch (e) {
+	// 	// the jwt isn't valid
+	// 	console.log('error jwt verify',e)
+	// }
+}
+
+const tokenRefreshLink = new TokenRefreshLink({
+	accessTokenField: 'token',
+	fetchAccessToken: getRefreshedToken,
+	handleError: (err:Error) => {
+		deleteLocalStorageToken();
+		console.error('There has been a problem getting a new access token: ', err);
+		// FIXME probably redirect user to login with an error "you've been logged out"?
+	},
+	handleFetch,
+	handleResponse: () => async (response:Response) => {
+		if(response.ok) {
+			const res: Get_Refresh_TokenQueryResult = await response.json()
+			if(res && res.data){
+				return res.data.token
+			} else {
+				throw new Error('The auth server did not answer with an expected refreshed token.')
+			}
+		}
+
+		throw new Error('The auth server did not answer successfully to the refresh token call.')
+	},
+	isTokenValidOrUndefined:  isLocalStorageTokenValidOrUndefined
+})
+
+const link = ApolloLink.from([
+	tokenRefreshLink,
+	setAuthorizationLink,
+	httpLink
+])
+
+const client = new ApolloClient({
+	cache: new InMemoryCache(),
+	link
+});
+
+interface Props {
+	children: JSX.Element[] | JSX.Element
+  }
+
+const Apollo = ( { children }:Props ) => {
+	return (
+		<ApolloProvider client={client}>
+			{children}
+		</ApolloProvider>
+	)
+}
+
+export default Apollo;

--- a/front-end/src/context/UserDetailsContext.tsx
+++ b/front-end/src/context/UserDetailsContext.tsx
@@ -1,6 +1,10 @@
-import React, { createContext, useState } from 'react'
-import { UserDetailsContextType } from '../types'
+import jwt from 'jsonwebtoken';
+import React, { createContext, useState } from 'react';
 
+import { getLocalStorageToken } from '../services/auth.service';
+import { UserDetailsContextType, JWTPayploadType } from '../types';
+
+const publicKey = process.env.REACT_APP_JWT_PUBLIC_KEY;
 const initialUserDetailsContext : UserDetailsContextType = {
 	id: null,
 	picture: null,
@@ -8,6 +12,18 @@ const initialUserDetailsContext : UserDetailsContextType = {
 		throw new Error('setUserDetailsContextState function must be overridden');
 	},
 	username: null
+}
+
+const accessToken = getLocalStorageToken();
+const tokenPayload = accessToken && publicKey && jwt.verify(accessToken, publicKey) as JWTPayploadType;
+
+if (tokenPayload && tokenPayload.sub && tokenPayload.name ){
+	const { sub:id, name:username } = tokenPayload
+
+	if (id && username){
+		initialUserDetailsContext.id = id;
+		initialUserDetailsContext.username = username;
+	}
 }
 
 export const UserDetailsContext = createContext(initialUserDetailsContext)

--- a/front-end/src/context/UserDetailsContext.tsx
+++ b/front-end/src/context/UserDetailsContext.tsx
@@ -4,7 +4,6 @@ import React, { createContext, useState } from 'react';
 import { getLocalStorageToken } from '../services/auth.service';
 import { UserDetailsContextType, JWTPayploadType } from '../types';
 
-const publicKey = process.env.REACT_APP_JWT_PUBLIC_KEY;
 const initialUserDetailsContext : UserDetailsContextType = {
 	id: null,
 	picture: null,
@@ -15,15 +14,19 @@ const initialUserDetailsContext : UserDetailsContextType = {
 }
 
 const accessToken = getLocalStorageToken();
-const tokenPayload = accessToken && publicKey && jwt.verify(accessToken, publicKey) as JWTPayploadType;
+try {
+	const tokenPayload = accessToken && jwt.decode(accessToken) as JWTPayploadType;
 
-if (tokenPayload && tokenPayload.sub && tokenPayload.name ){
-	const { sub:id, name:username } = tokenPayload
+	if (tokenPayload && tokenPayload.sub && tokenPayload.name ){
+		const { sub:id, name:username } = tokenPayload
 
-	if (id && username){
-		initialUserDetailsContext.id = id;
-		initialUserDetailsContext.username = username;
+		if (id && username){
+			initialUserDetailsContext.id = id;
+			initialUserDetailsContext.username = username;
+		}
 	}
+} catch {
+	//do nothing, the user will be authenticated as soon as there's a new call to the server.
 }
 
 export const UserDetailsContext = createContext(initialUserDetailsContext)

--- a/front-end/src/generated/graphql.tsx
+++ b/front-end/src/generated/graphql.tsx
@@ -2060,14 +2060,14 @@ export type PostFragment = (
     & Pick<Replies, 'id' | 'content' | 'created_at' | 'updated_at'>
     & { author: Maybe<(
       { __typename?: 'User' }
-      & Pick<User, 'username'>
+      & Pick<User, 'id' | 'username'>
     )> }
   )>, topic: Maybe<(
     { __typename?: 'topics' }
-    & Pick<Topics, 'name'>
+    & Pick<Topics, 'id' | 'name'>
   )>, type: (
     { __typename?: 'post_types' }
-    & Pick<Post_Types, 'name'>
+    & Pick<Post_Types, 'id' | 'name'>
   ) }
 );
 
@@ -2145,6 +2145,7 @@ export const PostFragmentDoc = gql`
   modification_date
   replies(order_by: {created_at: asc}) {
     author {
+      id
       username
     }
     id
@@ -2154,9 +2155,11 @@ export const PostFragmentDoc = gql`
   }
   title
   topic {
+    id
     name
   }
   type {
+    id
     name
   }
 }

--- a/front-end/src/index.tsx
+++ b/front-end/src/index.tsx
@@ -1,75 +1,9 @@
-import { ApolloProvider } from '@apollo/react-hooks';
-import { InMemoryCache } from 'apollo-cache-inmemory';
-import { ApolloClient } from 'apollo-client';
-import { ApolloLink } from 'apollo-link';
-import { setContext } from 'apollo-link-context';
-import { HttpLink } from 'apollo-link-http';
-import { TokenRefreshLink } from 'apollo-link-token-refresh';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
 import App from './App';
-import {
-	isLocalStorageTokenValidOrUndefined,
-	getLocalStorageToken,
-	getRefreshedToken,
-	storeLocalStorageToken,
-	deleteLocalStorageToken
-} from './services/auth.service';
-import { Get_Refresh_TokenQueryResult } from './generated/auth-graphql';
-
-const setAuthorizationLink = setContext(() => {
-	const token = getLocalStorageToken()
-	if (token) {
-		return { headers: { authorization: `Bearer ${token}` } }
-	} else {
-		return null
-	}
-});
-
-const httpLink = new HttpLink({
-	uri: process.env.REACT_APP_HASURA_GRAPHQL_URL
-});
-
-const tokenRefreshLink = new TokenRefreshLink({
-	accessTokenField: 'token',
-	fetchAccessToken: getRefreshedToken,
-	handleError: (err:Error) => {
-		deleteLocalStorageToken();
-		console.error('There has been a problem getting a new access token: ', err);
-		// FIXME probably redirect user to login with an error "you've been logged out"?
-	},
-	handleFetch: (accessToken) => storeLocalStorageToken(accessToken),
-	handleResponse: () => async (response:Response) => {
-		if(response.ok) {
-			const res: Get_Refresh_TokenQueryResult = await response.json()
-			if(res && res.data){
-				return res.data.token
-			} else {
-				throw new Error('The auth server did not answer with an expected refreshed token.')
-			}
-		}
-
-		throw new Error('The auth server did not answer successfully to the refresh token call.')
-	},
-	isTokenValidOrUndefined:  isLocalStorageTokenValidOrUndefined
-})
-
-const link = ApolloLink.from([
-	tokenRefreshLink,
-	setAuthorizationLink,
-	httpLink
-])
-
-export const client = new ApolloClient({
-	cache: new InMemoryCache(),
-	link
-});
 
 ReactDOM.render(
-	<ApolloProvider client={client}>
-		<App />
-	</ApolloProvider>,
-
+	<App />,
 	document.getElementById('root'),
 );

--- a/front-end/src/screens/MenuBar/index.tsx
+++ b/front-end/src/screens/MenuBar/index.tsx
@@ -1,15 +1,13 @@
-import jwt from 'jsonwebtoken'
 import React from 'react';
 import { useContext, useEffect } from 'react'
 import { Link } from 'react-router-dom';
-import { Menu } from 'semantic-ui-react'
+import { Menu, Icon } from 'semantic-ui-react'
 import styled from 'styled-components';
 
 import { UserDetailsContext } from '../../context/UserDetailsContext'
 import { useLogoutMutation } from '../../generated/auth-graphql';
 import { useRouter } from '../../hooks';
-import { getLocalStorageToken, logout } from '../../services/auth.service';
-import { JWTPayploadType } from '../../types';
+import { logout } from '../../services/auth.service';
 
 interface Props {
 	className?: string
@@ -17,41 +15,9 @@ interface Props {
 
 const MenuBar = ({ className } : Props): JSX.Element => {
 	const currentUser = useContext(UserDetailsContext);
-	const publicKey = process.env.REACT_APP_JWT_PUBLIC_KEY;
 	const [logoutMutation, { data, error }] = useLogoutMutation({ context: { uri : process.env.REACT_APP_AUTH_SERVER_GRAPHQL_URL } });
 	const { history } = useRouter();
-	const { id, setUserDetailsContextState, username } = currentUser;
-
-	useEffect(() => {
-		if (!id){
-			// no user stored in memory
-			// check in the local storage
-			const token = getLocalStorageToken()
-			if (token) {
-				try {
-					const tokenPayload = token && publicKey && jwt.verify(token, publicKey) as JWTPayploadType;
-
-					if (tokenPayload && tokenPayload.sub && tokenPayload.name ){
-						const id = tokenPayload.sub
-						const username =  tokenPayload.name
-
-						if (id && username){
-							setUserDetailsContextState((prevState) => {
-								return {
-									...prevState,
-									id,
-									username
-								}
-							})
-						}
-					}
-				} catch (e) {
-					// the jwt isn't valid
-					console.log('error jwt verify',e)
-				}
-			}
-		}
-	},[id, setUserDetailsContextState, publicKey]);
+	const { setUserDetailsContextState, username } = currentUser;
 
 	useEffect(() => {
 		if (data && data.logout && data.logout.message) {
@@ -75,7 +41,7 @@ const MenuBar = ({ className } : Props): JSX.Element => {
 			<Menu.Menu position="right">
 				{username
 					? <>
-						<Menu.Item>Hello {username}</Menu.Item>
+						<Menu.Item><Icon name='user circle' inverted /> {username}</Menu.Item>
 						<Menu.Item onClick={handleLogout}>Logout</Menu.Item>
 					</>
 					: <>

--- a/front-end/src/screens/Post/index.tsx
+++ b/front-end/src/screens/Post/index.tsx
@@ -13,9 +13,9 @@ export default () => {
 		return <div>Loading...</div>;
 	}
 
-	if (error || !data) {
-		return <div>ERROR</div>;
-	}
+	if (error) return <div> Error: {error.message}</div>;
 
-	return <Post data={data} />;
+	if (data) return <Post data={data} />;
+
+	return <div>Loading...</div>
 };

--- a/front-end/src/screens/Post/query.ts
+++ b/front-end/src/screens/Post/query.ts
@@ -11,6 +11,7 @@ const post = gql`
         modification_date
         replies(order_by: {created_at: asc}) {
             author {
+                id
                 username
             }
             id
@@ -20,9 +21,11 @@ const post = gql`
         }
         title
         topic {
+            id
             name
         }
         type {
+            id
             name
         }
     }

--- a/front-end/src/screens/VerifyEmail/index.tsx
+++ b/front-end/src/screens/VerifyEmail/index.tsx
@@ -26,7 +26,7 @@ const VerifyEmail = ({ className }:Props): JSX.Element => {
 
 		return (
 			<Header as='h2' icon>
-				<Icon name='bug' />
+				<Icon name='ambulance' />
 				{error && error.message ? error.message : errorMessage}
 			</Header>
 		)

--- a/front-end/src/services/auth.service.tsx
+++ b/front-end/src/services/auth.service.tsx
@@ -1,6 +1,4 @@
-import jwt from 'jsonwebtoken'
-
-import { UserDetailsContextType, JWTPayploadType } from '../types'
+import { UserDetailsContextType } from '../types'
 import { LoginResponse } from '../generated/auth-graphql';
 
 /**
@@ -26,39 +24,6 @@ export const getLocalStorageToken = (): string|null => {
 export const deleteLocalStorageToken = (): void => {
 	return localStorage.removeItem('Authorization');
 }
-
-/**
- * Tells whether the jwt token stored locally
- * is expired. It returns true if the token isn't set.
- */
-export const isLocalStorageTokenValidOrUndefined = (): boolean => {
-	let token = localStorage.getItem('Authorization') || null;
-
-	if (token) {
-		const tokenPayload = jwt.decode(token) as JWTPayploadType | null;
-
-		// if the token couldn't be decoded (tokenPayload is null) ask for a new one.
-		return tokenPayload ? tokenPayload.exp > Date.now() / 1000 : false
-	} else {
-		// if there's no token we shouldn't ask for a refresh token
-		return true
-	}
-};
-
-/**
- * Performs a call to the auth server
- * in the hope to get a new jwt token.
- */
-export const getRefreshedToken = () => (
-	fetch(`${process.env.REACT_APP_AUTH_SERVER_GRAPHQL_URL}`, {
-		body: JSON.stringify({ 'operationName':null,'query':'query get_new_token { token { token }}' }),
-		credentials: 'same-origin',
-		headers: {
-			'Content-Type': 'application/json'
-		},
-		method: 'POST'
-	})
-)
 
 /**
  * Store the user information in local context and call the function to store the received token


### PR DESCRIPTION
- closes #98 
- load the context info in the context instead of the Menubar (relic from the hacky first commits)
- move Apollo logic to a function component to use context
- added id to gql queries to let Apollo better handle the cache (got errors)
- added icons to user and changes for ambulance instead of bug in the error screen

How to test:
See if login, signup and logout work as before. Set the jwt to be Xmin, when you are logged in, wait Xmin for the jwt to expire and refresh the page. There should be a refresh token call, and the menu bar should show your username. It didn't in the past.