### PR TITLE
Topic tag post - Issue 103

### DIFF
--- a/front-end/src/screens/Post/Post.tsx
+++ b/front-end/src/screens/Post/Post.tsx
@@ -44,10 +44,10 @@ const PostContent = ({ post } : {post: PostFragment}) => {
 
 	return (
 		<>
-			<div className='post_info'>posted by <strong>{author.username}</strong> {moment.default(creation_date, 'YYYY-MM-DDTHH:mm:ss.SSS').fromNow()}</div>
-			<h3>{title}</h3>
-			<ReactMarkdown className='post_content' source={content} />
 			<div className='post_tags'><Tag>{topic && topic.name}</Tag></div>
+			<h3>{title}</h3>
+			<div className='post_info'>posted by <strong>{author.username}</strong> {moment.default(creation_date, 'YYYY-MM-DDTHH:mm:ss.SSS').fromNow()}</div>
+			<ReactMarkdown className='post_content' source={content} />
 		</>
 	);
 }
@@ -56,7 +56,9 @@ export default styled(Post)`
 	.post_info {
 		color: #555;
 		font-size: 1.2rem;
+		padding-bottom: 2rem;
 		margin-bottom: 2rem;
+		border-bottom: 1px solid #EEE;
 	}
 
 	.PostContent {
@@ -65,9 +67,14 @@ export default styled(Post)`
 		border: 1px solid #EEE;
 	}
 
+	.post_tags {
+		margin-bottom: 1.5rem;		
+	}
+
 	h3 {
 		font-family: 'Roboto';
-		margin-bottom: 1.5rem;
+		font-size: 2.4rem;
+		margin-bottom: 0.4rem;
 	}
 
 	.post_content {

--- a/front-end/src/ui-components/Tag.tsx
+++ b/front-end/src/ui-components/Tag.tsx
@@ -4,13 +4,10 @@ import styled from 'styled-components';
 export const Tag = styled(Label)`
     &.ui.label {
         font-size: 1rem;
-        font-weight: 500;
-        background-color: #B5AEAE;
+        font-weight: 400;
+        background-color: #393838;
         color: #FFF;
         border-radius: 0.2rem;
         letter-spacing: 0.05rem;
-        &:hover {
-            background-color: #8C8787;
-        }
     }
 `;


### PR DESCRIPTION
Addresses issues #103. Changed order slightly (tried also tag before author and author and tag in one line, but looks off visually). Removed hover style for tag and added subtle divider between info and md content.
<img width="723" alt="Screenshot 2019-12-12 at 10 36 14" src="https://user-images.githubusercontent.com/7072141/70701028-f6a26c80-1ccb-11ea-954c-846a2d387cda.png">
