### PR TITLE
CI for linting

### DIFF
--- a/auth-server/.gitlab-ci.yml
+++ b/auth-server/.gitlab-ci.yml
@@ -1,0 +1,53 @@
+stages:
+  - test
+  - build
+
+variables:
+  GIT_DEPTH: '3'
+  SIMPLECOV: 'true'
+  RUST_BACKTRACE: '1'
+  RUSTFLAGS: ''
+  CARGOFLAGS: ''
+
+cache:
+  key: '${CI_JOB_NAME}'
+  paths:
+    - node_modules/
+    - packages/*/node_modules/
+
+.branches: &branches
+  only:
+    - beta
+    - tags
+    - stable
+    - triggers
+    - master
+
+lint-front-end:
+  stage: test
+  image: node:12
+  script:
+    - curl -o- -L https://yarnpkg.com/install.sh | bash
+    - export PATH=$HOME/.yarn/bin:$PATH
+    - cd front-end
+    - yarn install
+    - yarn lint
+  rules:
+    - changes: # Will include the job and set to when:manual if any of the follow paths match a modified file.
+      - "front-end/*"
+  tags:
+    - linux-docker
+lint-back-end:
+  stage: test
+  image: node:12
+  script:
+    - curl -o- -L https://yarnpkg.com/install.sh | bash
+    - export PATH=$HOME/.yarn/bin:$PATH
+    - cd auth-server
+    - yarn install
+    - yarn lint
+  rules:
+    - changes: # Will include the job and set to when:manual if any of the follow paths match a modified file.
+      - "auth-server/*"
+  tags:
+    - linux-docker

--- a/auth-server/.gitlab-ci.yml
+++ b/auth-server/.gitlab-ci.yml
@@ -2,26 +2,11 @@ stages:
   - test
   - build
 
-variables:
-  GIT_DEPTH: '3'
-  SIMPLECOV: 'true'
-  RUST_BACKTRACE: '1'
-  RUSTFLAGS: ''
-  CARGOFLAGS: ''
-
 cache:
   key: '${CI_JOB_NAME}'
   paths:
     - node_modules/
     - packages/*/node_modules/
-
-.branches: &branches
-  only:
-    - beta
-    - tags
-    - stable
-    - triggers
-    - master
 
 lint-front-end:
   stage: test
@@ -33,7 +18,7 @@ lint-front-end:
     - yarn install
     - yarn lint
   rules:
-    - changes: # Will include the job and set to when:manual if any of the follow paths match a modified file.
+    - changes:
       - "front-end/*"
   tags:
     - linux-docker
@@ -47,7 +32,7 @@ lint-back-end:
     - yarn install
     - yarn lint
   rules:
-    - changes: # Will include the job and set to when:manual if any of the follow paths match a modified file.
+    - changes:
       - "auth-server/*"
   tags:
     - linux-docker


### PR DESCRIPTION
This is a copy from Fether, slightly modified.
I am not sure about:
```yaml
stages:
  - test
  - build

variables:
  GIT_DEPTH: '3'
  SIMPLECOV: 'true'
  RUST_BACKTRACE: '1'
  RUSTFLAGS: ''
  CARGOFLAGS: ''

cache:
  key: '${CI_JOB_NAME}'
  paths:
    - node_modules/
    - packages/*/node_modules/

.branches: &branches
  only:
    - beta
    - tags
    - stable
    - triggers
    - master
```

And about the rules. I'd like to run the script from `front-end` only when a file there has been changed or/and `auth-server` only when a file there has been changed.