### PR TITLE
Issue 102 - New Post Button Positioning

### DIFF
--- a/front-end/src/screens/Discussions/Discussions.tsx
+++ b/front-end/src/screens/Discussions/Discussions.tsx
@@ -60,7 +60,7 @@ export default styled(Discussions)`
 
 	@media only screen and (max-width: 576px) {
 		h3 {
-			margin-left: 1.5rem;
+			margin-left: 1.5rem!important;
 		}
 
 		.mainButtonContainer {
@@ -76,13 +76,22 @@ export default styled(Discussions)`
 
 	@media only screen and (max-width: 768px) {
 		h3 {
-			margin-left: 3rem;
+			margin-left: 0rem;
+		}
+
+		.mainButtonContainer {
+			margin: 1rem 0;
+			margin-top: 1rem!important;
 		}
 	}
 
 	@media only screen and (max-width: 991px) and (min-width: 768px) {
 		.ui[class*="tablet reversed"].grid {
 			flex-direction: column-reverse;
+		}
+
+		.mainButtonContainer {
+			margin-top: 1rem!important;
 		}
 	}
 

--- a/front-end/src/screens/Discussions/Discussions.tsx
+++ b/front-end/src/screens/Discussions/Discussions.tsx
@@ -58,15 +58,31 @@ const Discussions = ({ className, data }: Props) => {
 
 export default styled(Discussions)`
 
+	@media only screen and (max-width: 576px) {
+		h3 {
+			margin-left: 1.5rem;
+		}
+
+		.mainButtonContainer {
+			align-items: stretch!important;
+			margin: 1rem!important;
+
+			.newPostButton {
+				padding: 0.8rem 1rem;
+				border-radius: 0.5rem;
+			}
+		}
+	}
+
 	@media only screen and (max-width: 768px) {
 		h3 {
 			margin-left: 3rem;
 		}
 	}
 
-	@media only screen and (max-width: 576px) {
-		h3 {
-			margin-left: 1.5rem;
+	@media only screen and (max-width: 991px) and (min-width: 768px) {
+		.ui[class*="tablet reversed"].grid {
+			flex-direction: column-reverse;
 		}
 	}
 
@@ -87,10 +103,10 @@ export default styled(Discussions)`
 	}
 
 	.mainButtonContainer {
-		align-items: center;
+		align-items: flex-start;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
-		margin-top: 20px;
+		margin-top: 4rem;
 	}
 `;

--- a/front-end/src/screens/Home/HomeContent.tsx
+++ b/front-end/src/screens/Home/HomeContent.tsx
@@ -88,11 +88,11 @@ export default styled(HomeContent)`
 	}
 
 	.mainButtonContainer {
-		align-items: center;
+		align-items: flex-start;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
-		margin-top: 20px;
+		margin-top: 4rem;
 	}
 
 	Button.newPostButton {

--- a/front-end/src/screens/Home/HomeContent.tsx
+++ b/front-end/src/screens/Home/HomeContent.tsx
@@ -59,15 +59,40 @@ const HomeContent = ({ className, data }: Props) => {
 
 export default styled(HomeContent)`
 
-	@media only screen and (max-width: 768px) {
+	@media only screen and (max-width: 576px) {
 		h3 {
-			margin-left: 3rem;
+			margin-left: 1.5rem!important;
+		}
+
+		.mainButtonContainer {
+			align-items: stretch!important;
+			margin: 1rem!important;
+
+			.newPostButton {
+				padding: 0.8rem 1rem;
+				border-radius: 0.5rem;
+			}
 		}
 	}
 
-	@media only screen and (max-width: 576px) {
+	@media only screen and (max-width: 768px) {
 		h3 {
-			margin-left: 1.5rem;
+			margin-left: 0rem;
+		}
+
+		.mainButtonContainer {
+			margin: 1rem 0;
+			margin-top: 1rem!important;
+		}
+	}
+
+	@media only screen and (max-width: 991px) and (min-width: 768px) {
+		.ui[class*="tablet reversed"].grid {
+			flex-direction: column-reverse;
+		}
+
+		.mainButtonContainer {
+			margin-top: 1rem!important;
 		}
 	}
 
@@ -93,9 +118,5 @@ export default styled(HomeContent)`
 		flex-direction: column;
 		justify-content: center;
 		margin-top: 4rem;
-	}
-
-	Button.newPostButton {
-		margin-bottom: 10px
 	}
 `;

--- a/front-end/src/ui-components/Button.tsx
+++ b/front-end/src/ui-components/Button.tsx
@@ -12,7 +12,7 @@ export const Button = styled(SemanticButton).attrs({
 		text-transform: uppercase;
 		border-radius: 0.3rem;
 		border: none;
-		padding: 0.5rem 1rem;
+		padding: 0.7rem 1rem;
 		color: #fff;
     }
 

--- a/front-end/src/ui-components/Button.tsx
+++ b/front-end/src/ui-components/Button.tsx
@@ -7,7 +7,7 @@ export const Button = styled(SemanticButton).attrs({
 	
 	&.ui.button {   
         font-family: 'Roboto Mono';
-		font-size: 1.6rem;
+		font-size: 1.45rem;
 		font-weight: 500;
 		text-transform: uppercase;
 		border-radius: 0.3rem;


### PR DESCRIPTION
Left aligned button on desktop. Fixed reversed columns on mobile landscape and tablet portrait, so that the button is not hidden after the posts. Made button full stretch and slightly bigger on mobile portrait.

<img width="1094" alt="Screenshot 2019-12-12 at 13 55 05" src="https://user-images.githubusercontent.com/7072141/70714374-47c05980-1ce8-11ea-93bc-1b8f4dbb64a4.png">
<img width="330" alt="Screenshot 2019-12-12 at 13 55 21" src="https://user-images.githubusercontent.com/7072141/70714375-47c05980-1ce8-11ea-8457-9c252ab74e9e.png">
<img width="376" alt="Screenshot 2019-12-12 at 13 55 57" src="https://user-images.githubusercontent.com/7072141/70714378-4858f000-1ce8-11ea-887a-62c83e9c8dae.png">
