### PR TITLE
Add linting rule and align front and back

### DIFF
--- a/auth-server/.eslintrc.json
+++ b/auth-server/.eslintrc.json
@@ -20,11 +20,15 @@
         "@typescript-eslint"
     ],
     "rules": {
+        "@typescript-eslint/no-unused-vars": "error",
+        "arrow-spacing":["warn",{ "before": true, "after": true }],
         "comma-dangle": ["error", "never"],
+        "indent": ["error", "tab"],
+        "no-multiple-empty-lines": ["error", {"max": 1}],
+        "no-trailing-spaces": ["warn"],
+        "no-unused-vars": "off",
         "object-curly-spacing": ["error", "always"],
         "quotes": ["error", "single",  { "avoidEscape": true }],
-        "indent": ["error", "tab"],
-        "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": "error"
+        "switch-colon-spacing": ["error", {"after": true, "before": false}]  
     }
 }

--- a/auth-server/src/model/connection.ts
+++ b/auth-server/src/model/connection.ts
@@ -3,5 +3,3 @@ import * as connection from '../../knexfile'
 
 export default Knex(connection)
 
-
-

--- a/auth-server/src/services/auth.ts
+++ b/auth-server/src/services/auth.ts
@@ -78,7 +78,6 @@ export default class AuthService {
 			throw new Error('JWT token user not matching refresh token user')
 		}
 
-
 		await RefreshToken
 			.query()
 			.patch({ valid: false })
@@ -358,13 +357,11 @@ export default class AuthService {
 			})
 			.findById(resetToken.user_id)
 
-
 		await PasswordResetToken
 			.query()
 			.patch({ valid: false })
 			.findById(resetToken.id)
 	}
-
 
 	private getSignedToken({ id, username, email }): string {
 		const allowedRoles = ['user']

--- a/auth-server/test/resolvers/mutation/changeName.spec.ts
+++ b/auth-server/test/resolvers/mutation/changeName.spec.ts
@@ -36,7 +36,6 @@ describe('changeName mutation', () => {
 		const newName = 'new name'
 		await changeName(null, { newName }, fakectx)
 
-
 		const dbUser = await User
 			.query()
 			.where({ id: signupResult.user.id })

--- a/auth-server/test/resolvers/mutation/changePassword.spec.ts
+++ b/auth-server/test/resolvers/mutation/changePassword.spec.ts
@@ -41,7 +41,6 @@ describe('changePassword mutation', () => {
 
 		await changePassword(null, { oldPassword: password, newPassword }, fakectx)
 
-
 		const dbUser = await User
 			.query()
 			.where({ id: signupResult.user.id })

--- a/front-end/.eslintrc.json
+++ b/front-end/.eslintrc.json
@@ -40,6 +40,7 @@
         "no-unused-vars": "off",
         "object-curly-spacing": ["error", "always"],
         "quotes": ["error", "single",  { "avoidEscape": true }],
-        "sort-keys": ["error", "asc", {"caseSensitive": true, "natural": false, "minKeys": 2}]       
+        "sort-keys": ["error", "asc", {"caseSensitive": true, "natural": false, "minKeys": 2}],
+        "switch-colon-spacing": ["error", {"after": true, "before": false}]       
     }
 }

--- a/front-end/src/components/PostContent.tsx
+++ b/front-end/src/components/PostContent.tsx
@@ -5,7 +5,7 @@ import CreationLabel from '../ui-components/CreationLabel';
 import { PostFragment } from '../generated/graphql';
 import UpdateLabel from '../ui-components/UpdateLabel';
 
-const PostContent = ({ post } : {post: PostFragment}) => {
+const PostContent = ({ post }:{post: PostFragment}) => {
 	const { author, content, created_at, title, updated_at } = post;
 
 	if (!author || !author.username || !content) return <div>Post not available</div>

--- a/front-end/src/screens/Post/Comments.tsx
+++ b/front-end/src/screens/Post/Comments.tsx
@@ -13,7 +13,7 @@ interface Props{
 const Comments = ({ className, comments, firstComment=true }: Props) => {
 	return (
 		<div className={className}>
-			{ firstComment &&	<hr/> }
+			{firstComment &&	<hr/> }
 			<div className={firstComment ? '' : 'comment'} >
 				{comments.map((comment:CommentRecursiveFragment) =>
 					<Comment key={comment.id} comment={comment}/>


### PR DESCRIPTION
Added:
- "arrow-spacing":["warn",{ "before": true, "after": true }],
- "switch-colon-spacing": ["error", {"after": true, "before": false}]

I didn't add the alphabetical ordering on the back, because this rule is probably not the most useful IMO. 