### PR TITLE
Fix console warnings on Signup

### DIFF
--- a/front-end/src/components/Modal.tsx
+++ b/front-end/src/components/Modal.tsx
@@ -21,19 +21,19 @@ const MyModal = ({ className }: Props) => {
 		return (
 			<Modal
 				buttons={<Button
-					primary
+					content='Got it'
 					icon='check'
+					primary
 					onClick={dismissModal}
-				>Got it</Button>}
+				/>}
 				className={className}
 				centered
-				content={content}
 				dimmer='inverted'
 				open
 				onClose={dismissModal}
 				size='tiny'
 				title={title}
-			/>
+			>{content}</Modal>
 
 		);
 	};

--- a/front-end/src/screens/SignupForm/index.tsx
+++ b/front-end/src/screens/SignupForm/index.tsx
@@ -123,6 +123,11 @@ const SignupForm = ({ className }:Props): JSX.Element => {
 						>
 							Sign-up
 						</Button>
+						<Button
+							primary
+							disabled={loading}
+							onClick={() => setModal({ content: 'Hopho' ,title: 'You\'ve got some mail' })}
+						>Modal</Button>
 						{error && <FilteredError text={error.message}/>}
 					</div>
 				</Form>

--- a/front-end/src/screens/SignupForm/index.tsx
+++ b/front-end/src/screens/SignupForm/index.tsx
@@ -123,11 +123,6 @@ const SignupForm = ({ className }:Props): JSX.Element => {
 						>
 							Sign-up
 						</Button>
-						<Button
-							primary
-							disabled={loading}
-							onClick={() => setModal({ content: 'Hopho' ,title: 'You\'ve got some mail' })}
-						>Modal</Button>
 						{error && <FilteredError text={error.message}/>}
 					</div>
 				</Form>

--- a/front-end/src/ui-components/Modal.tsx
+++ b/front-end/src/ui-components/Modal.tsx
@@ -5,20 +5,21 @@ import styled from 'styled-components';
 type Props = ModalProps & {
 	buttons: React.ReactNode
 	content?: string
+	children?: React.ReactNode
 	className?: string
 	dismissModal?: () => void
 	title?: string
 }
 
 const Modal = (props : Props) => {
-	const { buttons, className, content, title } = props;
+	const { buttons, children, className, title, ...otherProps } = props;
 
 	return (
-		<SUIModal className={className} centered dimmer='inverted' open size='tiny' {...props}>
+		<SUIModal className={className} centered dimmer='inverted' open size='tiny' {...otherProps}>
 			<SUIModal.Header>{title}</SUIModal.Header>
 			<SUIModal.Content>
 				<SUIModal.Description>
-					<p>{content}</p>
+					<p>{children}</p>
 				</SUIModal.Description>
 			</SUIModal.Content>
 			<SUIModal.Actions>
@@ -32,7 +33,7 @@ export default styled(Modal)`
 &.ui.modal {
 	left: auto;
 	height: auto;
-	top: auto;
+	top: 25%;
 	font-size: 1.2rem;
 	border-radius: 0rem;
 


### PR DESCRIPTION
- closes #202 
- put the modal on the upper side of the screen rather than totally centered.

To test quickly just add the following button on the Signup page:
```js
<Button
	primary
	disabled={loading}
	onClick={() => setModal({ content: 'Hophop' ,title: 'hi' })}
>Modal</Button>	
```