### PR TITLE
Checkbox fix

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -6,6 +6,7 @@
   "homepage": "http://polkassembly.io/",
   "dependencies": {
     "@substrate/ui-components": "^0.2.4",
+    "@types/showdown": "^1.9.3",
     "apollo-cache": "^1.3.2",
     "apollo-cache-inmemory": "^1.6.3",
     "apollo-client": "^2.6.4",
@@ -28,11 +29,12 @@
     "react-hook-form": "^4.4.2",
     "react-icons": "^3.8.0",
     "react-markdown": "^4.2.2",
-    "react-mde": "^7.8.0",
+    "react-mde": "8.0.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.2.0",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.88.1",
+    "showdown": "^1.9.1",
     "styled-components": "^5.0.0-beta.11",
     "typescript": "3.7.4"
   },

--- a/front-end/src/components/PostContent.tsx
+++ b/front-end/src/components/PostContent.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
-import ReactMarkdown from 'react-markdown';
+import Showdown from 'showdown';
 
 import CreationLabel from '../ui-components/CreationLabel';
 import { PostFragment } from '../generated/graphql';
 import UpdateLabel from '../ui-components/UpdateLabel';
+
+const converter = new Showdown.Converter({
+	simplifiedAutoLink: true,
+	strikethrough: true,
+	tables: true,
+	tasklists: true
+});
 
 const PostContent = ({ post }:{post: PostFragment}) => {
 	const { author, content, created_at, title, updated_at } = post;
@@ -22,7 +29,7 @@ const PostContent = ({ post }:{post: PostFragment}) => {
 					updated_at={updated_at}
 				/>
 			</div>
-			<ReactMarkdown className='post_content' source={content} />
+			<div className='md' dangerouslySetInnerHTML={{ __html: converter.makeHtml(content) }}></div>
 		</>
 	);
 };

--- a/front-end/src/screens/Comment/EditableCommentContent.tsx
+++ b/front-end/src/screens/Comment/EditableCommentContent.tsx
@@ -1,8 +1,8 @@
 import { ApolloQueryResult } from 'apollo-client';
 import React, { useState, useContext, useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
-import ReactMarkdown from 'react-markdown';
 import { Icon } from 'semantic-ui-react';
+import Showdown from 'showdown';
 import styled from 'styled-components';
 
 import ContentForm from '../../components/ContentForm';
@@ -20,6 +20,13 @@ interface Props {
 	content: string,
 	refetch: (variables?: PostAndCommentsQueryVariables | undefined) => Promise<ApolloQueryResult<PostAndCommentsQuery>>
 }
+
+const converter = new Showdown.Converter({
+	simplifiedAutoLink: true,
+	strikethrough: true,
+	tables: true,
+	tasklists: true
+});
 
 const EditableCommenContent = ({ authorId, className, content, commentId, refetch }: Props) => {
 	const [isEditing, setIsEditing] = useState(false);
@@ -89,7 +96,7 @@ const EditableCommenContent = ({ authorId, className, content, commentId, refetc
 						</Form>
 						:
 						<>
-							<ReactMarkdown className='md' source={content} />
+							<div className='md' dangerouslySetInnerHTML={{ __html: converter.makeHtml(content) }}></div>
 							{id === authorId && <Button className={'social'} onClick={toggleEdit}><Icon name='edit' className='icon'/> Edit</Button>}
 						</>
 				}

--- a/front-end/src/ui-components/TextArea.tsx
+++ b/front-end/src/ui-components/TextArea.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import ReactMarkdown from 'react-markdown';
+/* import ReactMarkdown from 'react-markdown'; */
 import ReactMde, { commands }  from 'react-mde';
+import Showdown from 'showdown';
 import styled from 'styled-components';
 
 import 'react-mde/lib/styles/css/react-mde-all.css';
@@ -10,7 +11,8 @@ const StyledTextArea = styled.div`
     textarea {
 		border-radius: 0rem;
 		border: none!important;
-		color: #555!important;
+		color: #555 !important;
+		font-family: 'Roboto';
 		padding: 1rem 1.2rem!important;
 		line-height: 1.4!important;
 	}
@@ -197,6 +199,13 @@ interface Props {
     value: string
 }
 
+const converter = new Showdown.Converter({
+	simplifiedAutoLink: true,
+	strikethrough: true,
+	tables: true,
+	tasklists: true
+});
+
 export function TextArea(props: Props): React.ReactElement {
 	const listCommands = [
 		{
@@ -221,7 +230,7 @@ export function TextArea(props: Props): React.ReactElement {
 		<StyledTextArea className="container">
 			<ReactMde
 				commands={listCommands}
-				generateMarkdownPreview={markdown => Promise.resolve(<ReactMarkdown source={markdown} />) }
+				generateMarkdownPreview={markdown => Promise.resolve(converter.makeHtml(markdown)) }
 				name={props.name}
 				onChange={props.onChange}
 				onTabChange={setSelectedTab}

--- a/front-end/yarn.lock
+++ b/front-end/yarn.lock
@@ -2349,6 +2349,11 @@
     "@types/react" "*"
     "@types/recharts-scale" "*"
 
+"@types/showdown@^1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@types/showdown/-/showdown-1.9.3.tgz#eaa881b03a32d3720184731754d3025fc450b970"
+  integrity sha512-akvzSmrvY4J5d3tHzUUiQr0xpjd4Nb3uzWW6dtwzYJ+qW/KdWw5F8NLatnor5q/1LURHnzDA1ReEwCVqcatRnw==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -11306,10 +11311,10 @@ react-markdown@^4.2.2:
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
 
-react-mde@^7.8.0:
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/react-mde/-/react-mde-7.9.0.tgz#620a8fe0265883b7eba52077e8cf847c2f55d19d"
-  integrity sha512-nXLMDArq5Xsbn2OZLgoUXDIa5+Z8DBCJttPicTvyatMrSYmTBGCj+SqoqlRJuIfch6ldWgNSsjTDgJvk1Lk+nQ==
+react-mde@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/react-mde/-/react-mde-8.0.1.tgz#89ac025bd72b29799145266fdce7adf154a4edfd"
+  integrity sha512-vU5sPauykeAm05EA1sfiTUDco7UzFqh+HRqFDvi/FQCChUNtnbMgOqvPpIC1S10yl4eRfrM8rF0CbzggcS0+aw==
 
 react-popper@^1.3.4:
   version "1.3.7"
@@ -12298,6 +12303,13 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+showdown@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.9.1.tgz#134e148e75cd4623e09c21b0511977d79b5ad0ef"
+  integrity sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==
+  dependencies:
+    yargs "^14.2"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -14183,6 +14195,14 @@ yargs-parser@^13.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.0.tgz#cdd7a97490ec836195f59f3f4dbe5ea9e8f75f08"
+  integrity sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
@@ -14223,6 +14243,23 @@ yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
+
+yargs@^14.2:
+  version "14.2.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.2.tgz#2769564379009ff8597cdd38fba09da9b493c4b5"
+  integrity sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==
+  dependencies:
+    cliui "^5.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^15.0.0"
 
 yargs@^9.0.0:
   version "9.0.1"


### PR DESCRIPTION
Addressing #113  which is related to a [react-markdown issue](https://github.com/rexxars/react-markdown/issues/367)

react-markdown is not adding a class to the checkbox list to style them
<img width="301" alt="Screenshot 2020-01-09 at 10 12 17" src="https://user-images.githubusercontent.com/7072141/72054071-9271c900-32c8-11ea-9b1c-12acd1a13eba.png">


react-mde also works with [showdown](https://github.com/showdownjs/showdown), which renders checkboxes correctly, but adds another dependency. Also when rendering md in post and comments I had to use the showdown converter like this: `<div className='md' dangerouslySetInnerHTML={{ __html: converter.makeHtml(content) }} >` , which seems like a vulnerability. 

[Related discussion](https://github.com/andrerpena/react-mde/issues/161)