### PR TITLE
Remove checkboxes

### DIFF
--- a/front-end/src/screens/Comment/Comment.tsx
+++ b/front-end/src/screens/Comment/Comment.tsx
@@ -77,6 +77,9 @@ margin-top: 3rem;
 
 		ul {
 			margin-left: 3rem;
+			li > input {
+				display: none;
+			}
 		}
 
 		ol {

--- a/front-end/src/screens/Post/Post.tsx
+++ b/front-end/src/screens/Post/Post.tsx
@@ -122,6 +122,9 @@ export default styled(Post)`
 
 		ul, ol {
 			padding-left: 2rem;
+			li > input {
+				display: none;
+			}	
 		}
 
 		a {

--- a/front-end/src/ui-components/TextArea.tsx
+++ b/front-end/src/ui-components/TextArea.tsx
@@ -101,9 +101,8 @@ const StyledTextArea = styled.div`
 					font-size: 1.6rem;
 				}
 
-				input[type=checkbox] {
-					vertical-align: baseline;
-					list-style-type: none;
+				ul > li > input {
+					display: none;
 				}
 			}
 		}
@@ -209,7 +208,6 @@ export function TextArea(props: Props): React.ReactElement {
 				commands.strikeThroughCommand,
 				commands.codeCommand,
 				commands.imageCommand,
-				commands.checkedListCommand,
 				commands.orderedListCommand,
 				commands.unorderedListCommand
 			]


### PR DESCRIPTION
Closing #113. Removed the option from the text editor and added `ul > li > input { display: none; }` to post content and comments just in case someone writes it manually in md.