### PR TITLE
Styling detox

### DIFF
--- a/front-end/src/screens/Comment/Comment.tsx
+++ b/front-end/src/screens/Comment/Comment.tsx
@@ -1,6 +1,6 @@
 import { ApolloQueryResult } from 'apollo-client/core/types';
 import * as React from 'react';
-import styled from 'styled-components';
+import styled from '@xstyled/styled-components';
 
 import Comments from './Comments';
 import EditableCommentContent from './EditableCommentContent';
@@ -87,21 +87,22 @@ margin-top: 3rem;
 		}
 
 		a {
-			color: #FF5A47;
+			color: red_primary;
 
 			&:hover {
 				text-decoration: none;
-				color: #D94C3D;
-				border-bottom: 1px solid #D94C3D;
+				color: red_secondary;
 			}
 		}
 
 		blockquote {
 			margin-left: 0;
 			padding: 0 1em;
-			color: #7E7A7A;
-			border-left: 0.25rem solid #B5AEAE;
-			font-size: 1.4rem;
+			color: grey_primary;
+			border-left-style: solid;
+			border-left-width: 0.25rem;
+			border-left-color: grey_primary;
+			font-size: md;
 				& > :first-child {
 					margin-top: 0;
 				}
@@ -121,7 +122,7 @@ margin-top: 3rem;
 			font-size: 1.2rem;
 			background-color: rgba(0, 0, 0, 0.04);
 			border-radius: 3px;
-			color: #555252;
+			color: black_text;
 			&::before, &::after {
 			  letter-spacing: -0.2em;
 			}

--- a/front-end/src/screens/Comment/EditableCommentContent.tsx
+++ b/front-end/src/screens/Comment/EditableCommentContent.tsx
@@ -3,7 +3,7 @@ import React, { useState, useContext, useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import ReactMarkdown from 'react-markdown';
 import { Icon } from 'semantic-ui-react';
-import styled from 'styled-components';
+import styled from '@xstyled/styled-components';
 
 import ContentForm from '../../components/ContentForm';
 import { NotificationContext } from '../../context/NotificationContext';
@@ -21,7 +21,7 @@ interface Props {
 	refetch: (variables?: PostAndCommentsQueryVariables | undefined) => Promise<ApolloQueryResult<PostAndCommentsQuery>>
 }
 
-const EditableCommenContent = ({ authorId, className, content, commentId, refetch }: Props) => {
+const EditableCommentContent = ({ authorId, className, content, commentId, refetch }: Props) => {
 	const [isEditing, setIsEditing] = useState(false);
 	const { id } = useContext(UserDetailsContext);
 	const [newContent, setNewContent] = useState(content || '');
@@ -83,14 +83,14 @@ const EditableCommenContent = ({ authorId, className, content, commentId, refetc
 								rules={{ required: true }}
 							/>
 							<div className='button-container'>
-								<Button primary negative onClick={handleCancel}><Icon name='cancel' className='icon'/> Cancel</Button>
-								<Button primary onClick={handleSubmit(handleSave)}><Icon name='check' className='icon'/> Save</Button>
+								<Button secondary size='small' onClick={handleCancel}><Icon name='cancel' className='icon'/>Cancel</Button>
+								<Button primary size='small' onClick={handleSubmit(handleSave)}><Icon name='check' className='icon'/>Save</Button>
 							</div>
 						</Form>
 						:
 						<>
 							<ReactMarkdown className='md' source={content} />
-							{id === authorId && <Button className={'social'} onClick={toggleEdit}><Icon name='edit' className='icon'/> Edit</Button>}
+							{id === authorId && <Button className={'social'} onClick={toggleEdit}><Icon name='edit' className='icon'/>Edit</Button>}
 						</>
 				}
 			</div>
@@ -98,7 +98,7 @@ const EditableCommenContent = ({ authorId, className, content, commentId, refetc
 	);
 };
 
-export default styled(EditableCommenContent)`
+export default styled(EditableCommentContent)`
 	.button-container {
 		width: 100%;
 		display: flex;
@@ -107,7 +107,6 @@ export default styled(EditableCommenContent)`
 
 	.icon {
 		margin-top: -0.2rem!important;
-		margin-right: -0.3rem!important;
 		opacity: 1;
 	}
 }`;

--- a/front-end/src/screens/CreatePost/index.tsx
+++ b/front-end/src/screens/CreatePost/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 import { useForm, Controller } from 'react-hook-form';
-import { Button, Container, Grid } from 'semantic-ui-react';
-import styled from 'styled-components';
+import { Container, Grid } from 'semantic-ui-react';
+import styled from '@xstyled/styled-components';
 
 import ContentForm from '../../components/ContentForm';
 import { NotificationContext } from '../../context/NotificationContext';
@@ -10,6 +10,7 @@ import { useCreatePostMutation } from '../../generated/graphql';
 import { useRouter } from '../../hooks';
 import TopicsRadio from './TopicsRadio';
 import { NotificationStatus } from '../../types';
+import Button from '../../ui-components/Button';
 import FilteredError from '../../ui-components/FilteredError';
 import { Form } from '../../ui-components/Form';
 import TitleForm from '../../components/TitleForm';
@@ -90,10 +91,10 @@ const CreatePost = ({ className }:Props): JSX.Element => {
 
 						<div className={'mainButtonContainer'}>
 							<Button
+								primary
 								onClick={handleSubmit(handleSend)}
 								disabled={isSending || loading}
 								type='submit'
-								variant='primary'
 							>
 								{isSending || loading ? 'Creating...' : 'Create'}
 							</Button>
@@ -113,50 +114,5 @@ export default styled(CreatePost)`
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
-	}
-
-	.ui.button {
-		font-family: 'Roboto Mono';
-		font-size: 1.6rem;
-		font-weight: 500;
-		text-transform: uppercase;
-		border-radius: 0.3rem;
-		border: none;
-		padding: 0.5rem 1rem;
-		color: #fff;
-		background-color: #FF5A47;
-		&:focus, &:hover {
-			background-color: #D94C3D;
-			outline: none;
-		}
-	}
-
-	.ui.small.buttons {
-		margin: 0 0 1.875rem 0;
-
-		.ui.button {
-			font-size: 1rem;
-			background-color: #B5AEAE;
-			padding: 0.5rem 0.8rem;
-			border-radius: 0.2rem;
-			letter-spacing: 0.05rem;
-			line-height: 100%;
-			text-transform: none;
-			&:focus, &:hover {
-				background-color: #282828;
-				outline: none;
-			}
-		}
-	}
-
-	.fields {
-		.container {
-			padding-right: 5px;
-			padding-left: 5px;
-		}
-	}
-
-	textarea {
-		font-size: 1.4rem;
 	}
 `;

--- a/front-end/src/screens/MenuBar/index.tsx
+++ b/front-end/src/screens/MenuBar/index.tsx
@@ -67,7 +67,7 @@ export default styled(MenuBar)`
 		padding: 1.5rem 2rem;
 		font-family: 'Roboto Mono';
 		font-size: 1.4rem;
-		letter-spacing: 0.1rem;
+		letter-spacing: 0.15rem;
 		.item {
 			font-weight: 500;
 			padding: 0.5rem 0.5rem;

--- a/front-end/src/screens/Post/CreateRootComment.tsx
+++ b/front-end/src/screens/Post/CreateRootComment.tsx
@@ -2,7 +2,7 @@ import { ApolloQueryResult } from 'apollo-client';
 import React, { useState, useContext } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { Icon } from 'semantic-ui-react';
-import styled from 'styled-components';
+import styled from '@xstyled/styled-components';
 
 import ContentForm from '../../components/ContentForm';
 import { UserDetailsContext } from '../../context/UserDetailsContext';
@@ -67,8 +67,8 @@ const CreateRootComment = ({ className, onHide, postId, refetch }: Props) => {
 					rules={{ required: true }}
 				/>
 				<div className='button-container'>
-					<Button primary negative onClick={handleCancel}><Icon name='cancel'/> Cancel</Button>
-					<Button primary onClick={handleSubmit(handleSave)}><Icon name='reply'/> Reply</Button>
+					<Button secondary size='small' onClick={handleCancel}><Icon name='cancel'/>Cancel</Button>
+					<Button primary size='small' onClick={handleSubmit(handleSave)}><Icon name='reply'/>Reply</Button>
 				</div>
 			</>
 		</div>
@@ -86,7 +86,6 @@ export default styled(CreateRootComment)`
 
 	.icon {
 		margin-top: -0.2rem!important;
-		margin-right: -0.3rem!important;
 		opacity: 1;
 	}
 `;

--- a/front-end/src/screens/Post/EditablePostContent.tsx
+++ b/front-end/src/screens/Post/EditablePostContent.tsx
@@ -156,8 +156,8 @@ const EditablePostContent = ({ className, onReply, post, refetch }: Props) => {
 								rules={{ required: true }}
 							/>
 							<div className='button-container'>
-								<Button primary negative onClick={handleCancel}><Icon name='cancel' className='icon'/>Cancel</Button>
-								<Button primary onClick={handleSubmit(handleSave)}><Icon name='check' className='icon'/>Save</Button>
+								<Button secondary size='small' onClick={handleCancel}><Icon name='cancel' className='icon'/>Cancel</Button>
+								<Button primary size='small' onClick={handleSubmit(handleSave)}><Icon name='check' className='icon'/>Save</Button>
 							</div>
 						</Form>
 						:
@@ -174,7 +174,7 @@ const EditablePostContent = ({ className, onReply, post, refetch }: Props) => {
 };
 
 export default styled(EditablePostContent)`
-	margin: 2rem 0;
+	margin-bottom: 2rem;
 
 	.button-container {
 		width: 100%;

--- a/front-end/src/screens/Post/Post.tsx
+++ b/front-end/src/screens/Post/Post.tsx
@@ -1,7 +1,7 @@
 import { ApolloQueryResult } from 'apollo-client';
 import React, { useContext, useState } from 'react';
 import { Container, Grid } from 'semantic-ui-react';
-import styled from 'styled-components';
+import styled from '@xstyled/styled-components';
 
 import Comments from '../Comment/Comments';
 import NoPostFound from '../../components/NoPostFound';
@@ -57,33 +57,37 @@ const Post = ( { className, data, refetch }: Props ) => {
 
 export default styled(Post)`
 	.post_info {
-		color: #555;
-		font-size: 1.2rem;
+		color: text;
+		font-size: sm;
 		padding-bottom: 2rem;
 		margin-bottom: 2rem;
-		border-bottom: 1px solid #EEE;
+		border-bottom-style: solid;
+		border-bottom-width: 1px;
+		border-bottom-color: grey_light;
 	}
 
 	.PostContent {
-		background-color: #FFF;
-		padding: 2rem 3rem 2rem 3rem;
-		border: 1px solid #EEE;
+		background-color: white;
+		padding: 2rem 3rem 4rem 3rem;
+		border-style: solid;
+		border-width: 1px;
+		border-color: grey_light;
 	}
 
 	.post_tags {
-		margin-bottom: 1.5rem;
+		margin-bottom: 2.5rem;
 	}
 
 	h3 {
 		font-family: 'Roboto';
-		font-size: 2.4rem;
+		font-size: xl;
 		margin-bottom: 0.4rem;
 	}
 
 	.post_content {
-		color: #555;
+		color: text;
 		font-family: 'Roboto';
-		font-size: 1.45rem;
+		font-size: md;
 		line-height: 150%;
 		margin-bottom: 2rem;
 
@@ -108,16 +112,16 @@ export default styled(Post)`
 		}
 
 		h3 {
-			font-size: 1.45rem;
+			font-size: md;
 		}
 
 		h4 {
-			font-size: 1.45rem;
+			font-size: md;
 			font-family: 'Roboto Mono';
 		}
 
 		h5, h6 {
-			font-size: 1.2rem;
+			font-size: sm;
 		}
 
 		ul, ol {
@@ -128,20 +132,21 @@ export default styled(Post)`
 		}
 
 		a {
-			color: #FF5A47;
+			color: red_primary;
 
 			&:hover {
 				text-decoration: none;
-				color: #D94C3D;
-				border-bottom: 1px solid #D94C3D;
+				color: red_secondary;
 			}
 		}
 
 		blockquote {
 			margin-left: 0;
 			padding: 0 1em;
-			color: #7E7A7A;
-			border-left: 0.25rem solid #B5AEAE;
+			color: grey_primary;
+			border-left-style: solid;
+			border-left-width: 0.25rem;
+			border-left-color: grey_primary;
 			font-size: 1.6rem;
 				& > :first-child {
 					margin-top: 0;
@@ -157,12 +162,12 @@ export default styled(Post)`
 		}
 
 		code {
-			padding: 0.2em 0 0.2em 0;
+			padding: 0.2rem 0 0.2rem 0;
 			margin: 0;
-			font-size: 1.2rem;
+			font-size: sm;
 			background-color: rgba(0, 0, 0, 0.04);
 			border-radius: 3px;
-			color: #555252;
+			color: text;
 			&::before, &::after {
 			  letter-spacing: -0.2em;
 			}

--- a/front-end/src/screens/Post/Post.tsx
+++ b/front-end/src/screens/Post/Post.tsx
@@ -57,7 +57,7 @@ const Post = ( { className, data, refetch }: Props ) => {
 
 export default styled(Post)`
 	.post_info {
-		color: text;
+		color: black_text;
 		font-size: sm;
 		padding-bottom: 2rem;
 		margin-bottom: 2rem;
@@ -85,7 +85,7 @@ export default styled(Post)`
 	}
 
 	.post_content {
-		color: text;
+		color: black_text;
 		font-family: 'Roboto';
 		font-size: md;
 		line-height: 150%;
@@ -167,7 +167,7 @@ export default styled(Post)`
 			font-size: sm;
 			background-color: rgba(0, 0, 0, 0.04);
 			border-radius: 3px;
-			color: text;
+			color: black_text;
 			&::before, &::after {
 			  letter-spacing: -0.2em;
 			}

--- a/front-end/src/screens/Settings/index.tsx
+++ b/front-end/src/screens/Settings/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Grid, Divider, Container } from 'semantic-ui-react';
-import styled from 'styled-components';
+import styled from '@xstyled/styled-components';
 
 import Email from './email';
 import Fullname from './fullname';
@@ -32,13 +32,22 @@ const Settings = ({ className }:Props): JSX.Element => {
 };
 
 export default styled(Settings)`
-	background-color: #FFF;
+	background-color: white;
 	padding: 2rem 3rem 3rem 3rem!important;
+	border-style: solid;
+	border-width: 1px;
+	border-color: grey_light;
 
 	.ui.divider, .ui.divider:not(.vertical):not(.horizontal) {
-		margin: 2rem 0;
-		border-top: 1px solid #EEE;
+		margin: 3rem 0 2rem 0;
+		border-top-style: solid;
+		border-top-width: 1px;
+		border-top-color: grey_light;
 		border-bottom: none;
+	}
+
+	.button {
+		margin-top: 0.2rem;
 	}
 
 	@media only screen and (max-width: 576px) {

--- a/front-end/src/themes/theme.ts
+++ b/front-end/src/themes/theme.ts
@@ -11,7 +11,7 @@ export const theme = {
 		white: '#FFF'
 	},
 	fontSizes: {
-		input_text: '1.3rem',
+		input_text_size: '1.3rem',
 		lg: '2.1rem',
 		md: '1.5rem',
 		sm: '1.2rem',

--- a/front-end/src/themes/theme.ts
+++ b/front-end/src/themes/theme.ts
@@ -14,7 +14,8 @@ export const theme = {
 		input_text: '1.3rem',
 		lg: '2.1rem',
 		md: '1.5rem',
-		sm: '1.2rem'
+		sm: '1.2rem',
+		xl: '3rem'
 	},
 	radii: {
 		button_radius: '0.3rem'

--- a/front-end/src/themes/theme.ts
+++ b/front-end/src/themes/theme.ts
@@ -1,13 +1,13 @@
 export const theme = {
 	colors: {
 		black_primary: '#282828',
+		black_text: '#555',
 		grey_light: '#EEE',
 		grey_primary: '#706D6D',
 		grey_secondary: '#B5AEAE',
 		red_light: '#FFF1F0',
 		red_primary: '#FF5A47',
 		red_secondary: '#D94C3D',
-		text: '#555',
 		white: '#FFF'
 	},
 	fontSizes: {

--- a/front-end/src/themes/theme.ts
+++ b/front-end/src/themes/theme.ts
@@ -1,6 +1,6 @@
 export const theme = {
 	colors: {
-		black01: '#282828',
+		black_primary: '#282828',
 		grey_light: '#EEE',
 		grey_primary: '#706D6D',
 		grey_secondary: '#B5AEAE',
@@ -11,6 +11,7 @@ export const theme = {
 		white: '#FFF'
 	},
 	fontSizes: {
+		input_text: '1.3rem',
 		lg: '2.1rem',
 		md: '1.5rem',
 		sm: '1.2rem'

--- a/front-end/src/ui-components/Button.tsx
+++ b/front-end/src/ui-components/Button.tsx
@@ -12,15 +12,19 @@ export default styled(Button)`
 		font-size: md;
 		font-weight: 500;
 		text-transform: uppercase;
+		letter-spacing: 0.06rem;
 		border-radius: button_radius;
 		border: none;
-		padding: 0.7rem 1rem;
+		padding: 0.8rem 1.6rem;
+		.small {
+			font-size: sm;
+			padding: 0.6rem 1.2rem;
+		}
 		&.ui.primary.button {
 			background-color: red_primary;
-			color: white;
+			color: black_primary;
 			&:hover, &:focus {
 				background-color: red_secondary;
-				color: white;
 				outline: none;
 			}
 		}
@@ -41,15 +45,14 @@ export default styled(Button)`
 		}
 		&.ui.secondary.button {
 			background-color: white;
-			color: red_primary;
+			color: text;
 			border-style: solid;
-			border-color: red_secondary;
+			border-color: grey_secondary;
 			border-width: 0.1rem;
 			&:hover, &:focus {
-				background-color: red_light;
-				color: red_secondary;
+				background-color: grey_light;
 				border-style: solid;
-				border-color: red_secondary;
+				border-color: grey_primary;
 				border-width: 0.1rem;
 				outline: none;
 			}

--- a/front-end/src/ui-components/Button.tsx
+++ b/front-end/src/ui-components/Button.tsx
@@ -58,7 +58,7 @@ export default styled(Button)`
 			border-color: grey_secondary;
 			border-width: 0.1rem;
 			&:hover, &:focus {
-				color: text;
+				color: black_text;
 				background-color: grey_light;
 				border-style: solid;
 				border-color: grey_primary;

--- a/front-end/src/ui-components/Button.tsx
+++ b/front-end/src/ui-components/Button.tsx
@@ -16,9 +16,17 @@ export default styled(Button)`
 		border-radius: button_radius;
 		border: none;
 		padding: 0.8rem 1.6rem;
-		.small {
+		&.ui.tiny.button {
 			font-size: sm;
 			padding: 0.6rem 1.2rem;
+		}
+		&.ui.small.button {
+			font-size: md;
+			padding: 0.6rem 1.2rem;
+		}
+		&.ui.medium.button {
+			font-size: md;
+			padding: 0.8rem 1.6rem;
 		}
 		&.ui.primary.button {
 			background-color: red_primary;
@@ -45,11 +53,12 @@ export default styled(Button)`
 		}
 		&.ui.secondary.button {
 			background-color: white;
-			color: text;
+			color: grey_primary;
 			border-style: solid;
 			border-color: grey_secondary;
 			border-width: 0.1rem;
 			&:hover, &:focus {
+				color: text;
 				background-color: grey_light;
 				border-style: solid;
 				border-color: grey_primary;
@@ -76,6 +85,9 @@ export default styled(Button)`
 			font-size: sm;
 			border: none;
 			padding: 0.7rem 0.7rem;
+			text-transform: none;
+			letter-spacing: 0rem;
+			border-radius: 0.2rem;
 			&:hover{
 				background-color: grey_light;
 				border: none;
@@ -85,11 +97,13 @@ export default styled(Button)`
 			opacity: 1;
 		}
 		&.ui.social.negative.button {
-				background-color: white;
-				color: red_primary;
-				font-size: sm;
-				border: none;
-				padding: 0.7rem 0.7rem;
+			background-color: white;
+			color: red_primary;
+			font-size: sm;
+			border: none;
+			padding: 0.7rem 0.7rem;
+			text-transform: none;
+			letter-spacing: 0rem;
 			&:hover {
 				background-color: red_light;
 				border: none;

--- a/front-end/src/ui-components/CreationLabel.tsx
+++ b/front-end/src/ui-components/CreationLabel.tsx
@@ -1,6 +1,6 @@
 import * as moment from 'moment';
 import React from 'react';
-import styled from 'styled-components';
+import styled from '@xstyled/styled-components';
 
 interface Props{
     className?: string
@@ -16,13 +16,13 @@ const CreationLabel = ({ className, created_at, text='posted', username } : Prop
 };
 
 export default styled(CreationLabel)`
-    color: #7E7A7A;
+    color: grey_primary;
     font-weight: 400;
-    font-size: 1.2rem;
+    font-size: sm;
     margin-bottom: 0.6rem;
         
     span {
-        color: #555252;
+        color: black_text;
         font-weight: 500;
     }
 }`;

--- a/front-end/src/ui-components/Field.tsx
+++ b/front-end/src/ui-components/Field.tsx
@@ -7,10 +7,11 @@ function Field (props : SUIFormFieldProps){
 }
 
 export default styled(Field)`
-    margin-bottom: 1.25rem;
+    margin-bottom: 2rem;
 
     .text-muted {
+        color: grey_primary;
         font-size: 1.2rem;
-        margin: 0.5rem 0 0 0;
+        margin-top: 1rem;
     }
 `;

--- a/front-end/src/ui-components/Form.tsx
+++ b/front-end/src/ui-components/Form.tsx
@@ -41,7 +41,7 @@ const StyledForm = styled(SUIForm)`
     &.ui.form {
         .field {
             > label {
-                font-size: 1.3rem;
+                font-size: input_text_size;
                 font-weight: 500;
                 color: black_primary !important;
                 margin-bottom: 0.6rem;
@@ -70,7 +70,7 @@ const StyledForm = styled(SUIForm)`
             &:focus {
                 font-family: 'Roboto';
                 font-size: 1.3rem;
-                color: text;
+                color: black_text;
                 border-color: grey_primary;
                 border-radius: 0rem;
             }
@@ -80,7 +80,7 @@ const StyledForm = styled(SUIForm)`
         }
 
         input::selection, textarea::selection {
-            color: text;
+            color: black_text;
             background-color: grey_light;
         }
         

--- a/front-end/src/ui-components/Form.tsx
+++ b/front-end/src/ui-components/Form.tsx
@@ -43,6 +43,7 @@ const StyledForm = styled(SUIForm)`
             > label {
                 font-size: 1.3rem;
                 font-weight: 500;
+                color: black_primary !important;
                 margin-bottom: 0.6rem;
             }
         }

--- a/front-end/src/ui-components/Form.tsx
+++ b/front-end/src/ui-components/Form.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Form as SUIForm, FormProps as SUIFormProps } from 'semantic-ui-react';
-import styled from 'styled-components';
+import styled from '@xstyled/styled-components';
 
 import Input from './Input';
 import Field from './Field';
@@ -41,13 +41,14 @@ const StyledForm = styled(SUIForm)`
     &.ui.form {
         .field {
             > label {
-                font-size: 1.2rem;
+                font-size: 1.3rem;
                 font-weight: 500;
+                margin-bottom: 0.6rem;
             }
         }
 
         .fields {
-            margin-bottom: 1.875rem;
+            margin-bottom: 2rem;
 
             @media only screen and (max-width: 767px) {
                 margin-bottom: 1.25rem;
@@ -58,20 +59,28 @@ const StyledForm = styled(SUIForm)`
         input[type=file], input[type=number], input[type=password], input[type=search], input[type=tel], 
         input[type=text], input[type=time], input[type=url] {
             font-family: 'Roboto';
-            font-size: 1.2rem;
-            color: #282828;
+            font-size: 1.3rem;
+            color: black_primary;
             border: 1 px solid #EEE;
-            border-color: #EEE;
+            border-color: grey_light;
             border-radius: 0rem;
             text-indent: 0rem;
-            padding: 0.625rem 0.625 0.5rem 0.625;
+            padding: 1rem;
             &:focus {
                 font-family: 'Roboto';
-                font-size: 1.2rem;
-                color: #282828;
-                border: 1 px solid #EEE;
+                font-size: 1.3rem;
+                color: text;
+                border-color: grey_primary;
                 border-radius: 0rem;
             }
+            &:hover {
+                border-color: grey_secondary;
+            }
+        }
+
+        input::selection, textarea::selection {
+            color: text;
+            background-color: grey_light;
         }
         
     @media only screen and (max-width: 576px) {

--- a/front-end/src/ui-components/GlobalStyle.tsx
+++ b/front-end/src/ui-components/GlobalStyle.tsx
@@ -42,7 +42,7 @@ export const GlobalStyle = createGlobalStyle`
     }
 
     h1, h2, h3, h4, h5, h6 {
-        color: black01;
+        color: black_primary;
         font-family: 'Roboto';
         font-weight: 500;
         line-height: 100%;
@@ -51,7 +51,7 @@ export const GlobalStyle = createGlobalStyle`
 
     h3 {
         font-family: 'Roboto Mono';
-        font-size: 2.4rem;
+        font-size: 2.6rem;
         margin-bottom: 1.25rem;
     }
 

--- a/front-end/src/ui-components/GlobalStyle.tsx
+++ b/front-end/src/ui-components/GlobalStyle.tsx
@@ -15,7 +15,7 @@ export const GlobalStyle = createGlobalStyle`
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
         background-color: #F1F3F2;
-        color: #555252;
+        color: black_text;
     }
 
     pre {

--- a/front-end/src/ui-components/GlobalStyle.tsx
+++ b/front-end/src/ui-components/GlobalStyle.tsx
@@ -18,7 +18,15 @@ export const GlobalStyle = createGlobalStyle`
         color: #555252;
     }
 
+    pre {
+        display: inline-block;
+        max-width: 100%;
+        white-space: pre-wrap;
+    }
+
     code {
+        display: inline-block;
+        max-width: 100%;
         font-family: 'Roboto Mono', source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
         monospace;
     }

--- a/front-end/src/ui-components/Input.tsx
+++ b/front-end/src/ui-components/Input.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Form as SUIForm, FormInputProps as SUIFormInputProps } from 'semantic-ui-react';
-import styled from 'styled-components';
+import styled from '@xstyled/styled-components';
 
 function Input (props : SUIFormInputProps){
 	return <SUIForm.Input {...props}/>;
@@ -8,8 +8,8 @@ function Input (props : SUIFormInputProps){
 
 export default styled(Input)`
     font-family: 'Roboto';
-    font-size: 1.2rem;
-    color: #282828;
+    font-size: input_text;
+    color: black_primary;
     border: 1 px solid #EEE;
     border-radius: 0rem;
     padding: 0.625rem 0 0.5rem 0;


### PR DESCRIPTION
Apologies for changing a few things at once; I just wanted to style them holistically and clean things up a bit :)

- Primary button color had a contrast too low for accessibility; changed it to black and like it better actually
- Added button sizes
- Gave secondary button a calmer look and used it for cancel
- Changed social button font transform to look a bit more compact and distingushable
- Amped font sizes up a bit in post and forms
- Added input hover styles
- Fixed width bug when using the code tag in md
- Swapping some more values with xstyled variables, correcting a typo, small nits and cleanup

<img width="152" alt="Screenshot 2020-01-14 at 22 01 44" src="https://user-images.githubusercontent.com/7072141/72428535-33132d80-378e-11ea-997e-ca808172816a.png">
<img width="294" alt="Screenshot 2020-01-15 at 10 32 54" src="https://user-images.githubusercontent.com/7072141/72428536-33132d80-378e-11ea-8680-cefd7e2ff83a.png">
<img width="705" alt="Screenshot 2020-01-15 at 10 33 10" src="https://user-images.githubusercontent.com/7072141/72428538-33132d80-378e-11ea-868a-4c9daf6f3280.png">

I think this looks a little bit fresher. I want to see what we can do about the icons; they're a bit too heavy atm.
