### PR TITLE
Fix logout when no cookie

### DIFF
--- a/front-end/src/screens/MenuBar/index.tsx
+++ b/front-end/src/screens/MenuBar/index.tsx
@@ -22,12 +22,9 @@ const MenuBar = ({ className } : Props): JSX.Element => {
 	const { setUserDetailsContextState, username } = currentUser;
 
 	const handleLogout = () => {
-		logoutMutation()
-			.then(() => {
-				logout(setUserDetailsContextState);
-				history.push('/');
-			})
-			.catch( e => console.error(e));
+		logoutMutation().catch(e => console.error(e));
+		logout(setUserDetailsContextState);
+		history.push('/');
 	};
 
 	// Menu Items

--- a/front-end/src/screens/MenuBar/index.tsx
+++ b/front-end/src/screens/MenuBar/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactNode, useContext, useEffect, useState } from 'react';
+import { ReactNode, useContext, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Dropdown, Menu, Icon, Responsive, Sidebar, SidebarPusher } from 'semantic-ui-react';
 import styled from '@xstyled/styled-components';
@@ -17,22 +17,17 @@ interface Props {
 
 const MenuBar = ({ className } : Props): JSX.Element => {
 	const currentUser = useContext(UserDetailsContext);
-	const [logoutMutation, { data, error }] = useLogoutMutation({ context: { uri : process.env.REACT_APP_AUTH_SERVER_GRAPHQL_URL } });
+	const [logoutMutation] = useLogoutMutation({ context: { uri : process.env.REACT_APP_AUTH_SERVER_GRAPHQL_URL } });
 	const { history } = useRouter();
 	const { setUserDetailsContextState, username } = currentUser;
 
-	useEffect(() => {
-		if (data && data.logout && data.logout.message) {
-			logout(setUserDetailsContextState);
-			history.push('/');
-		}
-
-		if (error) console.error(error);
-
-	},[data, error, history, setUserDetailsContextState]);
-
 	const handleLogout = () => {
-		logoutMutation();
+		logoutMutation()
+			.then(() => {
+				logout(setUserDetailsContextState);
+				history.push('/');
+			})
+			.catch( e => console.error(e));
 	};
 
 	// Menu Items

--- a/front-end/src/screens/NotFound/index.tsx
+++ b/front-end/src/screens/NotFound/index.tsx
@@ -23,7 +23,7 @@ const NotFound = ({ className }:Props): JSX.Element => {
 					<br/>
 					<br/>
 					<>
-						<img width={100} src='broken-chain.png'/>
+						<img alt={'broken chain'} width={100} src='broken-chain.png'/>
 					</>
 					<br/>
 					<br/>


### PR DESCRIPTION
closes https://github.com/paritytech/polkassembly/issues/238
removed a warning for an alt on images.

To test login, remove the cookie set by auth-server and logout. It should work.. and print an error in the console.