### PR TITLE
Sign-up explanations

### DIFF
--- a/front-end/src/screens/SignupForm/index.tsx
+++ b/front-end/src/screens/SignupForm/index.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { useForm } from 'react-hook-form';
-import { Grid } from 'semantic-ui-react';
-import styled from 'styled-components';
+import { Grid, Icon, Popup } from 'semantic-ui-react';
+import styled from '@xstyled/styled-components';
 
 import { ModalContext } from '../../context/ModalContext';
 import { UserDetailsContext } from '../../context/UserDetailsContext';
@@ -73,7 +73,13 @@ const SignupForm = ({ className }:Props): JSX.Element => {
 					</Form.Group>
 					<Form.Group>
 						<Form.Field width={16}>
-							<label>Full Name</label>
+							<label>
+								Full Name&nbsp;
+								<Popup
+									trigger={<Icon name='question circle'/>}
+									content='We only use your name as a more readable alternative to your username.'
+								/>
+							</label>
 							<input
 								className={errors.name ? 'error' : ''}
 								name='name'
@@ -84,7 +90,13 @@ const SignupForm = ({ className }:Props): JSX.Element => {
 					</Form.Group>
 					<Form.Group>
 						<Form.Field width={16}>
-							<label>Email</label>
+							<label>
+								Email&nbsp;
+								<Popup
+									trigger={<Icon name='question circle'/>}
+									content='We only use your email for password recovery and to receive notifications if you wish to opt-in.'
+								/>
+							</label>
 							<input
 								className={errors.email ? 'error' : ''}
 								name='email'
@@ -146,5 +158,9 @@ export default styled(SignupForm)`
 
 	.errorText {
 		color: #fe4850
+	}
+
+	i.icon.question.circle:before {
+		color: grey_secondary;
 	}
 `;

--- a/front-end/src/screens/SignupForm/index.tsx
+++ b/front-end/src/screens/SignupForm/index.tsx
@@ -74,10 +74,10 @@ const SignupForm = ({ className }:Props): JSX.Element => {
 					<Form.Group>
 						<Form.Field width={16}>
 							<label>
-								Full Name&nbsp;
+								Display Name&nbsp;
 								<Popup
 									trigger={<Icon name='question circle'/>}
-									content='We only use your name as a more readable alternative to your username.'
+									content='We only use your display name as a more readable alternative to your username.'
 									style={{ marginLeft: '-0.7rem' }}
 								/>
 							</label>

--- a/front-end/src/screens/SignupForm/index.tsx
+++ b/front-end/src/screens/SignupForm/index.tsx
@@ -78,6 +78,7 @@ const SignupForm = ({ className }:Props): JSX.Element => {
 								<Popup
 									trigger={<Icon name='question circle'/>}
 									content='We only use your name as a more readable alternative to your username.'
+									style={{ marginLeft: '-0.7rem' }}
 								/>
 							</label>
 							<input
@@ -95,6 +96,7 @@ const SignupForm = ({ className }:Props): JSX.Element => {
 								<Popup
 									trigger={<Icon name='question circle'/>}
 									content='We only use your email for password recovery and to receive notifications if you wish to opt-in.'
+									style={{ marginLeft: '-0.7rem' }}
 								/>
 							</label>
 							<input

--- a/front-end/src/ui-components/Form.tsx
+++ b/front-end/src/ui-components/Form.tsx
@@ -38,6 +38,17 @@ const StyledForm = styled(SUIForm)`
         }
     }
 
+    .text-muted {
+        color: grey_primary;
+
+        a {
+            color: grey_primary;
+            border-bottom-style: solid;
+            border-bottom-width: 1px;
+            border-bottom-color: grey_primary;
+        }
+    }
+
     &.ui.form {
 
         .field


### PR DESCRIPTION
Closes #234 and #243 - added popups with explanations
<img width="515" alt="Screenshot 2020-01-27 at 11 22 09" src="https://user-images.githubusercontent.com/7072141/73168026-511b4f00-40f9-11ea-98a1-cca70e3b4016.png">
<img width="537" alt="Screenshot 2020-01-27 at 11 33 15" src="https://user-images.githubusercontent.com/7072141/73168027-511b4f00-40f9-11ea-9f38-1bf70a0faf0c.png">

For links in forms, I tried red, but to distinguish it from error messages, I prefer grey with underline (looks also a bit calmer).
<img width="532" alt="Screenshot 2020-01-27 at 11 33 54" src="https://user-images.githubusercontent.com/7072141/73168088-6e501d80-40f9-11ea-9192-bfcd1e34868e.png">


