### PR TITLE
Docker retry

### DIFF
--- a/auth-server/docker-compose-test.yaml
+++ b/auth-server/docker-compose-test.yaml
@@ -2,19 +2,22 @@ version: "3.6"
 services:
   postgres-test:
     image: postgres
+    restart: always
     ports:
-      - "5433:5432"
+      - "5433:5433"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: governance-auth-test
+      POSTGRES_DATABASE: governance-auth-test
+      PGPORT: 5433
   auth-test:
     image: paritytech/polkassembly-auth-test
+    restart: always
     depends_on:
       - "postgres-test"
     environment:
       NODE_ENV: test
-      TEST_DATABASE_URL: "postgres://postgres:postgres@postgres-test:5433/governance-auth-test"
+      TEST_DATABASE_URL: postgres://postgres:postgres@postgres-test:5433/governance-auth-test
       SENDGRID_API_KEY: ""
       REACT_APP_AUTH_URL: "http://localhost:8010"
       REACT_APP_SERVER_URL: "http://localhost:8080/v1/graphql"

--- a/auth-server/docker-compose-test.yaml
+++ b/auth-server/docker-compose-test.yaml
@@ -17,7 +17,7 @@ services:
       - "postgres-test"
     environment:
       NODE_ENV: test
-      TEST_DATABASE_URL: postgres://postgres:postgres@postgres-test:5433/governance-auth-test
+      TEST_DATABASE_URL: "postgres://postgres:postgres@postgres-test:5433/governance-auth-test"
       SENDGRID_API_KEY: ""
       REACT_APP_AUTH_URL: "http://localhost:8010"
       REACT_APP_SERVER_URL: "http://localhost:8080/v1/graphql"

--- a/auth-server/package.json
+++ b/auth-server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "oauth 2.0 server for polkassembly",
   "scripts": {
-    "test": "./test.sh",
+    "test": "docker build -f test.Dockerfile -t paritytech/polkassembly-auth-test . && docker-compose -f docker-compose-test.yaml up --abort-on-container-exit",
     "test:dangerous": "knex migrate:latest && mocha -r ts-node/register test/**/*.spec.ts",
     "start": "yarn tsc && node build/src/index.js",
     "lint": "eslint . --ext .js,.ts",


### PR DESCRIPTION
- removes additional test.sh
- forces postgres to use 5433
- helps a bit for https://github.com/paritytech/polkassembly/issues/197