### PR TITLE
Prevent proposal bot from impersonating anyone

### DIFF
--- a/hasura/hasura-migrations/migrations/1580897919204_update_permission_proposal_bot_public_table_posts/down.yaml
+++ b/hasura/hasura-migrations/migrations/1580897919204_update_permission_proposal_bot_public_table_posts/down.yaml
@@ -1,0 +1,24 @@
+- args:
+    role: proposal_bot
+    table:
+      name: posts
+      schema: public
+  type: drop_insert_permission
+- args:
+    permission:
+      check: {}
+      columns:
+      - author_id
+      - content
+      - title
+      - topic_id
+      - type_id
+      localPresets:
+      - key: ""
+        value: ""
+      set: {}
+    role: proposal_bot
+    table:
+      name: posts
+      schema: public
+  type: create_insert_permission

--- a/hasura/hasura-migrations/migrations/1580897919204_update_permission_proposal_bot_public_table_posts/up.yaml
+++ b/hasura/hasura-migrations/migrations/1580897919204_update_permission_proposal_bot_public_table_posts/up.yaml
@@ -1,0 +1,26 @@
+- args:
+    role: proposal_bot
+    table:
+      name: posts
+      schema: public
+  type: drop_insert_permission
+- args:
+    permission:
+      check:
+        author_id:
+          _eq: X-Hasura-User-Id
+      columns:
+      - author_id
+      - content
+      - title
+      - topic_id
+      - type_id
+      localPresets:
+      - key: ""
+        value: ""
+      set: {}
+    role: proposal_bot
+    table:
+      name: posts
+      schema: public
+  type: create_insert_permission


### PR DESCRIPTION
Proposal bot can only insert a post with its own ID.