### PR TITLE
Simple comment avatar

### DIFF
--- a/front-end/src/components/Comment/Comment.tsx
+++ b/front-end/src/components/Comment/Comment.tsx
@@ -5,6 +5,7 @@ import styled from '@xstyled/styled-components';
 import Comments from './Comments';
 import EditableCommentContent from './EditableCommentContent';
 import { CommentRecursiveFragment, ProposalPostAndCommentsQueryVariables, ProposalPostAndCommentsQuery, ReferendumPostAndCommentsQueryVariables, DiscussionPostAndCommentsQueryVariables, ReferendumPostAndCommentsQuery, DiscussionPostAndCommentsQuery } from '../../generated/graphql';
+import Avatar from '../../ui-components/Avatar';
 import CreationLabel from '../../ui-components/CreationLabel';
 import UpdateLabel from '../../ui-components/UpdateLabel';
 
@@ -20,8 +21,13 @@ export const Comment = ({ className, comment, refetch } : Props) => {
 	if (!author || !author.id || !author.username || !content) return <div>Comment not available</div>;
 
 	return (
-		<>
-			<div className={className}>
+		<div className={className}>
+			<Avatar
+				className='avatar'
+				displayname={author.name}
+				username={author.username}
+			/>
+			<div className='comment-box'>
 				<CreationLabel
 					created_at={created_at}
 					displayname={author.name}
@@ -48,17 +54,32 @@ export const Comment = ({ className, comment, refetch } : Props) => {
 						: null
 				}
 			</div>
-		</>
+		</div>
 	);
 };
 
 export default styled(Comment)`
-	background-color: white;
-	padding: 2rem 3rem 2rem 3rem;
-	border-style: solid;
-	border-width: 1px;
-	border-color: grey_light;
-	margin-bottom: 1rem;
+	display: flex;
+
+	.avatar {
+		display: inline-block;
+		flex: 0 0 4rem;
+		margin-right: 2rem;
+
+		@media only screen and (max-width: 576px) {
+			display: none;
+		}
+	}
+
+	.comment-box {
+		background-color: white;
+		padding: 2rem 3rem 2rem 3rem;
+		border-style: solid;
+		border-width: 1px;
+		border-color: grey_light;
+		margin-bottom: 1rem;
+		width: 100%;
+	}
 
 	.md {
 		margin-top: 1rem;

--- a/front-end/src/ui-components/Avatar.tsx
+++ b/front-end/src/ui-components/Avatar.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from '@xstyled/styled-components';
+
+interface Props {
+    className?: string
+	displayname?: string | null
+	username: string | null
+}
+
+const Avatar = ({ className, displayname, username }: Props) => {
+
+	return (
+		<div className={className}>
+			{displayname ? displayname.substring(0, 1) : username?.substring(0, 1)}
+		</div>
+	);
+};
+
+export default styled(Avatar)`
+	border-radius: 50%;
+	display: inline-block;
+	vertical-align: top;
+	overflow: hidden;
+	text-transform: uppercase;
+	text-align: center;
+	background-color: grey_primary;
+	color: white;
+	width: 4rem;
+	height: 4rem;
+	font-size: lg;
+	line-height: 4rem;
+`;


### PR DESCRIPTION
Just to get started: a simple avatar next to a comment taking a user's initial as a placeholder. Can be replaced by address identicons or potentially profile images later on.

<img width="731" alt="Screenshot 2020-02-12 at 16 43 01" src="https://user-images.githubusercontent.com/7072141/74351527-8097b000-4db7-11ea-9b1d-c59c9e411456.png">
