### PR TITLE
Comment overflow fix

### DIFF
--- a/front-end/src/components/Comment/Comment.tsx
+++ b/front-end/src/components/Comment/Comment.tsx
@@ -83,13 +83,17 @@ export default styled(Comment)`
 		border-width: 1px;
 		border-color: grey_light;
 		margin-bottom: 1rem;
-		width: 100%;
+		width: calc(100% - 6rem);
+
+		@media only screen and (max-width: 576px) {
+			width: 100%;
+		}
 	}
 
 	.md {
 		margin-top: 1rem;
-
 		font-size: 1.4rem;
+		overflow-wrap: break-word;
 
 		h1, h2 {
 			font-size: 1.6rem;

--- a/front-end/src/components/Comment/Comments.tsx
+++ b/front-end/src/components/Comment/Comments.tsx
@@ -41,4 +41,5 @@ const Comments = ({ className, comments, refetch }: Props) => {
 };
 
 export default styled(Comments)`
+	margin-top: 4rem;
 `;

--- a/front-end/src/components/Post/PostContent.tsx
+++ b/front-end/src/components/Post/PostContent.tsx
@@ -73,6 +73,7 @@ export default styled(PostContent)`
 		font-size: md;
 		line-height: 150%;
 		margin-bottom: 2rem;
+		overflow-wrap: break-word;
 
 		p, blockquote, ul, ol, dl, table {
 			margin: 0 0 1.5rem 0;

--- a/front-end/src/ui-components/TextArea.tsx
+++ b/front-end/src/ui-components/TextArea.tsx
@@ -67,6 +67,7 @@ const StyledTextArea = styled.div`
 
 			.mde-preview-content {
 				padding: 1rem 1.2rem!important;
+				overflow-wrap: break-word;
 
 				h1, h2, h3, h4, h5, h6 {
 					font-family: Roboto;


### PR DESCRIPTION
Closing #361 

Also added a bit of space between post and comment feed, and `overflow-wrap: break-word;`in `PostContent` too.

<img width="806" alt="Screenshot 2020-02-18 at 16 02 17" src="https://user-images.githubusercontent.com/7072141/74748193-67d04400-5268-11ea-98cc-9720252cdf21.png">
