### PR TITLE
Getting remote schema url from env vars

### DIFF
--- a/hasura/docker-compose.yaml.example
+++ b/hasura/docker-compose.yaml.example
@@ -34,3 +34,5 @@ services:
       HASURA_GRAPHQL_UNAUTHORIZED_ROLE: 'anonymous'
       HASURA_POST_SUBSCRIPTION_HOOK: "http://localhost:8010/auth/post/subscription"
       HASURA_POST_SUBSCRIPTION_SECRET: "<shared secret key with auth server>"
+      HASURA_AUTH_SERVER_REMOTE_SCHEMA: http://auth-server-service:8010/auth/graphql
+      HASURA_CHAIN_DB_REMOTE_SHCEMA: http://nodewatcher.nodewatcher:4466

--- a/hasura/hasura-migrations/migrations/1582552076335_table_posts_drop_remote_relationship_author/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582552076335_table_posts_drop_remote_relationship_author/down.yaml
@@ -1,0 +1,13 @@
+- args:
+    hasura_fields:
+    - author_id
+    name: author
+    remote_field:
+      user:
+        arguments:
+          id: $author_id
+    remote_schema: auth
+    table:
+      name: posts
+      schema: public
+  type: create_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552076335_table_posts_drop_remote_relationship_author/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582552076335_table_posts_drop_remote_relationship_author/up.yaml
@@ -1,0 +1,6 @@
+- args:
+    name: author
+    table:
+      name: posts
+      schema: public
+  type: delete_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552087743_table_comments_drop_remote_relationship_author/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582552087743_table_comments_drop_remote_relationship_author/down.yaml
@@ -1,0 +1,13 @@
+- args:
+    hasura_fields:
+    - author_id
+    name: author
+    remote_field:
+      user:
+        arguments:
+          id: $author_id
+    remote_schema: auth
+    table:
+      name: comments
+      schema: public
+  type: create_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552087743_table_comments_drop_remote_relationship_author/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582552087743_table_comments_drop_remote_relationship_author/up.yaml
@@ -1,0 +1,6 @@
+- args:
+    name: author
+    table:
+      name: comments
+      schema: public
+  type: delete_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552105476_update_remote_schema_auth/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582552105476_update_remote_schema_auth/down.yaml
@@ -1,0 +1,11 @@
+- args:
+    name: auth
+  type: remove_remote_schema
+- args:
+    definition:
+      forward_client_headers: true
+      headers: []
+      timeout_seconds: 60
+      url: http://localhost:8010/auth/graphql
+    name: auth
+  type: add_remote_schema

--- a/hasura/hasura-migrations/migrations/1582552105476_update_remote_schema_auth/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582552105476_update_remote_schema_auth/up.yaml
@@ -1,0 +1,11 @@
+- args:
+    name: auth
+  type: remove_remote_schema
+- args:
+    definition:
+      forward_client_headers: true
+      headers: []
+      timeout_seconds: 60
+      url_from_env: HASURA_AUTH_SERVER_REMOTE_SCHEMA
+    name: auth
+  type: add_remote_schema

--- a/hasura/hasura-migrations/migrations/1582552134767_table_posts_create_remote_relationship_author/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582552134767_table_posts_create_remote_relationship_author/down.yaml
@@ -1,0 +1,6 @@
+- args:
+    name: author
+    table:
+      name: posts
+      schema: public
+  type: delete_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552134767_table_posts_create_remote_relationship_author/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582552134767_table_posts_create_remote_relationship_author/up.yaml
@@ -1,0 +1,13 @@
+- args:
+    hasura_fields:
+    - author_id
+    name: author
+    remote_field:
+      user:
+        arguments:
+          id: $author_id
+    remote_schema: auth
+    table:
+      name: posts
+      schema: public
+  type: create_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552151971_table_comments_create_remote_relationship_author/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582552151971_table_comments_create_remote_relationship_author/down.yaml
@@ -1,0 +1,6 @@
+- args:
+    name: author
+    table:
+      name: comments
+      schema: public
+  type: delete_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552151971_table_comments_create_remote_relationship_author/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582552151971_table_comments_create_remote_relationship_author/up.yaml
@@ -1,0 +1,13 @@
+- args:
+    hasura_fields:
+    - author_id
+    name: author
+    remote_field:
+      user:
+        arguments:
+          id: $author_id
+    remote_schema: auth
+    table:
+      name: comments
+      schema: public
+  type: create_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552229731_table_onchain_links_drop_remote_relationship_onchain_proposal/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582552229731_table_onchain_links_drop_remote_relationship_onchain_proposal/down.yaml
@@ -1,0 +1,14 @@
+- args:
+    hasura_fields:
+    - onchain_proposal_id
+    name: onchain_proposal
+    remote_field:
+      proposals:
+        arguments:
+          where:
+            proposalId: $onchain_proposal_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: create_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552229731_table_onchain_links_drop_remote_relationship_onchain_proposal/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582552229731_table_onchain_links_drop_remote_relationship_onchain_proposal/up.yaml
@@ -1,0 +1,6 @@
+- args:
+    name: onchain_proposal
+    table:
+      name: onchain_links
+      schema: public
+  type: delete_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552237735_table_onchain_links_drop_remote_relationship_onchain_referendum/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582552237735_table_onchain_links_drop_remote_relationship_onchain_referendum/down.yaml
@@ -1,0 +1,14 @@
+- args:
+    hasura_fields:
+    - onchain_referendum_id
+    name: onchain_referendum
+    remote_field:
+      referendums:
+        arguments:
+          where:
+            referendumId: $onchain_referendum_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: create_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552237735_table_onchain_links_drop_remote_relationship_onchain_referendum/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582552237735_table_onchain_links_drop_remote_relationship_onchain_referendum/up.yaml
@@ -1,0 +1,6 @@
+- args:
+    name: onchain_referendum
+    table:
+      name: onchain_links
+      schema: public
+  type: delete_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552248166_table_onchain_links_drop_remote_relationship_onchain_motion/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582552248166_table_onchain_links_drop_remote_relationship_onchain_motion/down.yaml
@@ -1,0 +1,14 @@
+- args:
+    hasura_fields:
+    - onchain_motion_id
+    name: onchain_motion
+    remote_field:
+      motions:
+        arguments:
+          where:
+            motionProposalId: $onchain_motion_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: create_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552248166_table_onchain_links_drop_remote_relationship_onchain_motion/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582552248166_table_onchain_links_drop_remote_relationship_onchain_motion/up.yaml
@@ -1,0 +1,6 @@
+- args:
+    name: onchain_motion
+    table:
+      name: onchain_links
+      schema: public
+  type: delete_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552281519_update_remote_schema_chain-db/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582552281519_update_remote_schema_chain-db/down.yaml
@@ -1,0 +1,11 @@
+- args:
+    name: chain-db
+  type: remove_remote_schema
+- args:
+    definition:
+      forward_client_headers: false
+      headers: []
+      timeout_seconds: 60
+      url: http://localhost:4466
+    name: chain-db
+  type: add_remote_schema

--- a/hasura/hasura-migrations/migrations/1582552281519_update_remote_schema_chain-db/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582552281519_update_remote_schema_chain-db/up.yaml
@@ -1,0 +1,11 @@
+- args:
+    name: chain-db
+  type: remove_remote_schema
+- args:
+    definition:
+      forward_client_headers: true
+      headers: []
+      timeout_seconds: 60
+      url_from_env: HASURA_CHAIN_DB_REMOTE_SHCEMA
+    name: chain-db
+  type: add_remote_schema

--- a/hasura/hasura-migrations/migrations/1582552468902_table_onchain_links_create_remote_relationship_onchain_proposal/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582552468902_table_onchain_links_create_remote_relationship_onchain_proposal/down.yaml
@@ -1,0 +1,6 @@
+- args:
+    name: onchain_proposal
+    table:
+      name: onchain_links
+      schema: public
+  type: delete_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552468902_table_onchain_links_create_remote_relationship_onchain_proposal/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582552468902_table_onchain_links_create_remote_relationship_onchain_proposal/up.yaml
@@ -1,0 +1,14 @@
+- args:
+    hasura_fields:
+    - onchain_proposal_id
+    name: onchain_proposal
+    remote_field:
+      proposal:
+        arguments:
+          where:
+            id: $onchain_proposal_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: create_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552496160_table_onchain_links_create_remote_relationship_onchain_referendum/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582552496160_table_onchain_links_create_remote_relationship_onchain_referendum/down.yaml
@@ -1,0 +1,6 @@
+- args:
+    name: onchain_referendum
+    table:
+      name: onchain_links
+      schema: public
+  type: delete_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552496160_table_onchain_links_create_remote_relationship_onchain_referendum/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582552496160_table_onchain_links_create_remote_relationship_onchain_referendum/up.yaml
@@ -1,0 +1,14 @@
+- args:
+    hasura_fields:
+    - onchain_referendum_id
+    name: onchain_referendum
+    remote_field:
+      referendum:
+        arguments:
+          where:
+            id: $onchain_referendum_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: create_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552517341_table_onchain_links_create_remote_relationship_onchain_motion/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582552517341_table_onchain_links_create_remote_relationship_onchain_motion/down.yaml
@@ -1,0 +1,6 @@
+- args:
+    name: onchain_motion
+    table:
+      name: onchain_links
+      schema: public
+  type: delete_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582552517341_table_onchain_links_create_remote_relationship_onchain_motion/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582552517341_table_onchain_links_create_remote_relationship_onchain_motion/up.yaml
@@ -1,0 +1,14 @@
+- args:
+    hasura_fields:
+    - onchain_motion_id
+    name: onchain_motion
+    remote_field:
+      motion:
+        arguments:
+          where:
+            id: $onchain_motion_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: create_remote_relationship

--- a/kubernetes/polkassembly/hasura-config.yaml
+++ b/kubernetes/polkassembly/hasura-config.yaml
@@ -12,3 +12,5 @@ data:
   HASURA_GRAPHQL_UNAUTHORIZED_ROLE: anonymous
   HASURA_POST_SUBSCRIPTION_HOOK: http://auth-server-service:8010/auth/graphql
   HASURA_POST_SUBSCRIPTION_SECRET: $HASURA_POST_SUBSCRIPTION_SECRET
+  HASURA_AUTH_SERVER_REMOTE_SCHEMA: http://auth-server-service:8010/auth/graphql
+  HASURA_CHAIN_DB_REMOTE_SHCEMA: http://nodewatcher.nodewatcher:4466

--- a/kubernetes/polkassembly/hasura-deployment.yaml
+++ b/kubernetes/polkassembly/hasura-deployment.yaml
@@ -57,6 +57,16 @@ spec:
             configMapKeyRef:
               key: HASURA_POST_SUBSCRIPTION_SECRET
               name: hasura-config
+        - name: HASURA_AUTH_SERVER_REMOTE_SCHEMA
+          valueFrom:
+            configMapKeyRef:
+              key: HASURA_AUTH_SERVER_REMOTE_SCHEMA
+              name: hasura-config
+        - name: HASURA_CHAIN_DB_REMOTE_SHCEMA
+          valueFrom:
+            configMapKeyRef:
+              key: HASURA_CHAIN_DB_REMOTE_SHCEMA
+              name: hasura-config
         image: hasura/graphql-engine:pull2395-7ea7f82c
         imagePullPolicy: IfNotPresent
         name: graphql-engine


### PR DESCRIPTION
Closes: https://github.com/paritytech/polkassembly/issues/372

This is a big change. We can also edit old remote schema migration files so change is small. Should we use this or other solution.