### PR TITLE
Fix onchain links

### DIFF
--- a/hasura/hasura-migrations/migrations/1582631584192_table_onchain_links_create_remote_relationship_onchain_proposal/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582631584192_table_onchain_links_create_remote_relationship_onchain_proposal/down.yaml
@@ -1,0 +1,13 @@
+- args:
+    hasura_fields:
+    - onchain_proposal_id
+    remote_field:
+      proposal:
+        arguments:
+          where:
+            id: $onchain_proposal_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: update_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582631584192_table_onchain_links_create_remote_relationship_onchain_proposal/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582631584192_table_onchain_links_create_remote_relationship_onchain_proposal/up.yaml
@@ -1,0 +1,14 @@
+- args:
+    hasura_fields:
+    - onchain_proposal_id
+    name: onchain_proposal
+    remote_field:
+      proposals:
+        arguments:
+          where:
+            proposalId: $onchain_proposal_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: update_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582631619424_table_onchain_links_drop_remote_relationship_onchain_proposal/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582631619424_table_onchain_links_drop_remote_relationship_onchain_proposal/down.yaml
@@ -1,0 +1,14 @@
+- args:
+    hasura_fields:
+    - onchain_proposal_id
+    name: onchain_proposal
+    remote_field:
+      proposals:
+        arguments:
+          where:
+            proposalId: $onchain_proposal_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: create_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582631619424_table_onchain_links_drop_remote_relationship_onchain_proposal/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582631619424_table_onchain_links_drop_remote_relationship_onchain_proposal/up.yaml
@@ -1,0 +1,6 @@
+- args:
+    name: onchain_proposal
+    table:
+      name: onchain_links
+      schema: public
+  type: delete_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582631659991_table_onchain_links_create_remote_relationship_onchain_referendum/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582631659991_table_onchain_links_create_remote_relationship_onchain_referendum/down.yaml
@@ -1,0 +1,13 @@
+- args:
+    hasura_fields:
+    - onchain_motion_id
+    remote_field:
+      motion:
+        arguments:
+          where:
+            id: $onchain_motion_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: update_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582631659991_table_onchain_links_create_remote_relationship_onchain_referendum/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582631659991_table_onchain_links_create_remote_relationship_onchain_referendum/up.yaml
@@ -1,0 +1,14 @@
+- args:
+    hasura_fields:
+    - onchain_referendum_id
+    name: onchain_referendum
+    remote_field:
+      referendums:
+        arguments:
+          where:
+            referendumId: $onchain_referendum_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: update_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582631766314_table_onchain_links_create_remote_relationship_onchain_motion/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582631766314_table_onchain_links_create_remote_relationship_onchain_motion/down.yaml
@@ -1,0 +1,13 @@
+- args:
+    hasura_fields:
+    - onchain_motion_id
+    remote_field:
+      motion:
+        arguments:
+          where:
+            id: $onchain_motion_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: update_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582631766314_table_onchain_links_create_remote_relationship_onchain_motion/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582631766314_table_onchain_links_create_remote_relationship_onchain_motion/up.yaml
@@ -1,0 +1,14 @@
+- args:
+    hasura_fields:
+    - onchain_motion_id
+    name: onchain_motion
+    remote_field:
+      motions:
+        arguments:
+          where:
+            motionProposalId: $onchain_motion_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: update_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582631823541_table_onchain_links_create_remote_relationship_onchain_proposal/down.yaml
+++ b/hasura/hasura-migrations/migrations/1582631823541_table_onchain_links_create_remote_relationship_onchain_proposal/down.yaml
@@ -1,0 +1,6 @@
+- args:
+    name: onchain_proposal
+    table:
+      name: onchain_links
+      schema: public
+  type: delete_remote_relationship

--- a/hasura/hasura-migrations/migrations/1582631823541_table_onchain_links_create_remote_relationship_onchain_proposal/up.yaml
+++ b/hasura/hasura-migrations/migrations/1582631823541_table_onchain_links_create_remote_relationship_onchain_proposal/up.yaml
@@ -1,0 +1,14 @@
+- args:
+    hasura_fields:
+    - onchain_proposal_id
+    name: onchain_proposal
+    remote_field:
+      proposals:
+        arguments:
+          where:
+            proposalId: $onchain_proposal_id
+    remote_schema: chain-db
+    table:
+      name: onchain_links
+      schema: public
+  type: create_remote_relationship


### PR DESCRIPTION
The previous big migration PR introduces mistakes:
- we shouldn't link on chain-db.proposal, chain-db.referendum.. but rather referendumS, proposalS to fix another problem related to front-end queries (https://github.com/paritytech/polkassembly/pull/280).
- the link should be made on chain-db.referendumId, chain-db.proposalId.. rather than chain-db.id..

This should fix it. Please carefully review and merge if ok.