### PR TITLE
Address dropdown styling

### DIFF
--- a/front-end/src/components/Balance.tsx
+++ b/front-end/src/components/Balance.tsx
@@ -25,7 +25,7 @@ const Balance = ({ api, address }: Props) => {
 
 	return (
 		<div className='text-muted'>
-			{formatBalance(balance)} KSM available
+			{formatBalance(balance)} available
 		</div>
 	);
 };

--- a/front-end/src/components/Post/AddressDropdown.tsx
+++ b/front-end/src/components/Post/AddressDropdown.tsx
@@ -49,10 +49,12 @@ const AddressDropdown = ({ accounts, className, defaultAddress, filterAccounts, 
 		className={className}
 		onChange={_onAccountChange}
 		options={addressOptions}
-		trigger={<div className='address-wrapper'><Address
-			accountName={dropdownList[selectedAddress]}
-			address={defaultAddress}
-		/></div>}
+		trigger={<div className='address-wrapper'>
+			<Address
+				accountName={dropdownList[selectedAddress]}
+				address={defaultAddress}
+			/>
+		</div>}
 		value={selectedAddress}
 	/>;
 };

--- a/front-end/src/components/Post/AddressDropdown.tsx
+++ b/front-end/src/components/Post/AddressDropdown.tsx
@@ -49,10 +49,10 @@ const AddressDropdown = ({ accounts, className, defaultAddress, filterAccounts, 
 		className={className}
 		onChange={_onAccountChange}
 		options={addressOptions}
-		trigger={<Address
+		trigger={<div className='address-wrapper'><Address
 			accountName={dropdownList[selectedAddress]}
 			address={defaultAddress}
-		/>}
+		/></div>}
 		value={selectedAddress}
 	/>;
 };
@@ -62,11 +62,22 @@ export default styled(AddressDropdown)`
 	border-color: grey_light;
 	border-style: solid;
 	border-width: 1px;
-	padding: .2rem;
-	padding-left: 1rem;
+	padding: 1rem .4rem .4rem 1.2rem;
 
-	> div {
-		width: 90%;
+	.address-wrapper {
 		display: inline-block;
+	}
+
+	.visible.menu.transition {
+		width: 100%;
+		border-radius: 0;
+	}
+
+	.dropdown.icon {
+		position: absolute;
+		right: 0rem;
+		top: -0.5rem;
+		padding: 1.6rem 0.8rem;
+		float: right;
 	}
 `;

--- a/front-end/src/screens/Settings/address.tsx
+++ b/front-end/src/screens/Settings/address.tsx
@@ -216,27 +216,6 @@ const Address = ({ className }: Props): JSX.Element => {
 };
 
 export default styled(Address)`
-	font-family: font_default;
-
-	.image {
-		margin-right: 2rem;
-	}
-
-	.content {
-		position: absolute;
-		top: 20%;
-		line-height: 1.6rem;
-	}
-
-	.header {
-		color: black_text;
-		font-size: sm;
-	}
-
-	.description {
-		color: grey_primary;
-		font-size: xs;
-	}
 
 	.button-container {
 		position: absolute;

--- a/front-end/src/ui-components/Address.tsx
+++ b/front-end/src/ui-components/Address.tsx
@@ -27,8 +27,24 @@ const Address = ({ address, accountName, className }: Props): JSX.Element => (
 );
 
 export default styled(Address)`
+	position: relative;
+	display: flex;
+	align-items: center;
+
 	.content {
+		padding-left: 1rem;
 		display: inline-block;
-		padding-left: 10px;
+		line-height: 1.6rem;
+	}
+
+	.header {
+		color: black_text;
+		font-weight: 500;
+		font-size: sm;
+	}
+
+	.description {
+		color: grey_primary;
+		font-size: xs;
 	}
 `;

--- a/front-end/src/ui-components/Form.tsx
+++ b/front-end/src/ui-components/Form.tsx
@@ -123,12 +123,11 @@ const StyledForm = styled(SUIForm)`
 		}
 	}
 
+	.ui.dropdown,
 	.ui.selection.dropdown {
 		margin-bottom: 1.2rem;
 		border-radius: 0rem;
-	}
 
-	.ui.dropdown {
 		.menu .active.item {
 			font-weight: 500;
 		}


### PR DESCRIPTION
Styled address dropdown (caret and addresses aligned, full width dropdown menu)

Addresses the styling mentioned in #435

<img width="434" alt="Screenshot 2020-03-04 at 11 00 19" src="https://user-images.githubusercontent.com/7072141/75868296-231bdf80-5e08-11ea-9f97-eeb65570b105.png">
<img width="441" alt="Screenshot 2020-03-04 at 11 00 28" src="https://user-images.githubusercontent.com/7072141/75868305-2747fd00-5e08-11ea-95ae-3569884752f4.png">



