### PR TITLE
No restart for docker test

### DIFF
--- a/auth-server/docker-compose-test.yaml
+++ b/auth-server/docker-compose-test.yaml
@@ -2,7 +2,7 @@ version: "3.6"
 services:
   postgres-test:
     image: postgres
-    restart: always
+    restart: "no"
     ports:
       - "5433:5433"
     environment:
@@ -12,7 +12,7 @@ services:
       PGPORT: 5433
   auth-test:
     image: paritytech/polkassembly-auth-test
-    restart: always
+    restart: "no"
     depends_on:
       - "postgres-test"
     environment:


### PR DESCRIPTION
I just realized that `node_module/mocha` was eating a lot of CPU running in background for this docker very rarely used.. setting it to restart=no to prevent getting it started automatically with others when the docker daemon starts.