### PR TITLE
Set ip in migration for nodewatcher

### DIFF
--- a/hasura/hasura-migrations/migrations/1578932276990_create_remote_schema_chain-db/up.yaml
+++ b/hasura/hasura-migrations/migrations/1578932276990_create_remote_schema_chain-db/up.yaml
@@ -3,6 +3,6 @@
       forward_client_headers: false
       headers: []
       timeout_seconds: 60
-      url: http://nodewatcher.nodewatcher:4466
+      url: http://35.189.196.74:4000
     name: chain-db
   type: add_remote_schema


### PR DESCRIPTION
I needed to set the nodewatcher IP for the migration to execute successfully