### PR TITLE
Kirushik/security tools setup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,18 +6,22 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       3
 
-# Enable static security scanning of the codebase
+# Enable Gitlab's static security scanning of the codebase
 include:
   - template: SAST.gitlab-ci.yml
 variables:
   SAST_DISABLE_DIND: "true"
   SCAN_KUBERNETES_MANIFESTS: "true"
 
-# Enable dependencies scanning
+# Enable Gitlab's dependencies scanning
 include:
   - template: Dependency-Scanning.gitlab-ci.yml
 variables:
   DS_DISABLE_DIND: "true"
+
+# Enable Gitlab's license compatibility scanning
+include:
+  - template: License-Scanning.gitlab-ci.yml
 
 stages:
   - test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,10 @@ include:
   - template: Dependency-Scanning.gitlab-ci.yml
   - template: License-Scanning.gitlab-ci.yml
 
+kubesec-sast:
+  variables:
+    ANALYZER_TARGET_DIR: "."
+
 stages:
   - test
   - dockerize

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,12 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       3
 
+include:
+  - template: SAST.gitlab-ci.yml
+variables:
+  SAST_DISABLE_DIND: "true"
+  SCAN_KUBERNETES_MANIFESTS: "true"
+
 stages:
   - test
   - dockerize

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ include:
 variables:
   SAST_DISABLE_DIND: "true"
   SCAN_KUBERNETES_MANIFESTS: "true"
+  ANALYZER_TARGET_DIR: "auth_server/"
 
 # Enable Gitlab's dependencies scanning
 include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ include:
 
 kubesec-sast:
   variables:
-    ANALYZER_TARGET_DIR: "."
+    ANALYZER_TARGET_DIR: "kubernetes/"
 
 stages:
   - test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,23 +5,16 @@ variables:
   DOCKER_TAG:                      '$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA'
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       3
+  # Variables required by Gitlab scanning
+  SAST_DISABLE_DIND:               "true"
+  SCAN_KUBERNETES_MANIFESTS:       "true"
+  ANALYZER_TARGET_DIR:             "auth-server/"
+  DS_DISABLE_DIND:                 "true"
 
-# Enable Gitlab's static security scanning of the codebase
+# Enable Gitlab's security scanning
 include:
   - template: SAST.gitlab-ci.yml
-variables:
-  SAST_DISABLE_DIND: "true"
-  SCAN_KUBERNETES_MANIFESTS: "true"
-  ANALYZER_TARGET_DIR: "auth_server/"
-
-# Enable Gitlab's dependencies scanning
-include:
   - template: Dependency-Scanning.gitlab-ci.yml
-variables:
-  DS_DISABLE_DIND: "true"
-
-# Enable Gitlab's license compatibility scanning
-include:
   - template: License-Scanning.gitlab-ci.yml
 
 stages:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,11 +6,18 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       3
 
+# Enable static security scanning of the codebase
 include:
   - template: SAST.gitlab-ci.yml
 variables:
   SAST_DISABLE_DIND: "true"
   SCAN_KUBERNETES_MANIFESTS: "true"
+
+# Enable dependencies scanning
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+variables:
+  DS_DISABLE_DIND: "true"
 
 stages:
   - test


### PR DESCRIPTION
This enables some preliminary setup security and license scanning, mostly aimed at the `auth-server` subfolder.

We would need some more clever configuration to make it work with our "multiple projects pretending to be a single one" folder structure; Gitlab expects "one project per repo" by default.