### PR TITLE
Use identity before nickname

### DIFF
--- a/front-end/src/ui-components/Address.tsx
+++ b/front-end/src/ui-components/Address.tsx
@@ -23,14 +23,13 @@ const Address = ({ address, accountName, className }: Props): JSX.Element => {
 	useEffect(() => {
 		let unsubscribe: () => void;
 
-		if (!api) {
-			console.error('polkadot/api not set');
+		if (!api || !api.isReady) {
+			console.error('polkadot/api not set or not ready');
 			return;
 		}
 
-		api.derive.accounts.info(address, ((info: DeriveAccountInfo) =>
-			setDisplay(info.nickname || '')
-		))
+		api.derive.accounts.info(address, (info: DeriveAccountInfo) =>
+			setDisplay(info.identity.display || info.nickname || ''))
 			.then(unsub => { unsubscribe = unsub; })
 			.catch(e => console.error(e));
 


### PR DESCRIPTION
- really closes #498 

To test, change the env to connect to kusama rpc node.
change `address` with an address such as `FcxNWVy5RESDsErjwyZmPCW6Z8Y3fbfLzmou34YZTrbcraL`, and load any page containing the address component. you should see ` 🍺 Gav 🥃 ` when the api is ready (can take a couple seconds).

Nickname was empty for most current council users on Kusama.