### PR TITLE
Docker internal documentation for Mac

### DIFF
--- a/hasura/README.md
+++ b/hasura/README.md
@@ -55,6 +55,8 @@ So add these entries in /etc/hosts
 127.0.0.1       nodewatcher.nodewatcher
 ```
 
+As Docker only supports host networking on Linux, Mac users need to replace the host names in the hasura migrations yaml files with `http://host.docker.internal`.
+
 ### Migration
 
 We are using a [preview of hasura](https://github.com/hasura/graphql-engine/pull/2395#issuecomment-547378585), migration must therefore be applied manually with the `hasura-dev` cli.

--- a/hasura/docker-compose.yaml.example
+++ b/hasura/docker-compose.yaml.example
@@ -37,3 +37,6 @@ services:
       HASURA_EVENT_SECRET: "<shared secret key with auth server>"
       HASURA_AUTH_SERVER_REMOTE_SCHEMA: http://auth-server-service:8010/auth/graphql
       HASURA_CHAIN_DB_REMOTE_SCHEMA: http://nodewatcher.nodewatcher:4466
+      # Remote schemas on Mac OS workaround:
+      # HASURA_AUTH_SERVER_REMOTE_SCHEMA: "http://host.docker.internal:8010/auth/graphql"
+      # HASURA_CHAIN_DB_REMOTE_SCHEMA: "http://host.docker.internal:4466"

--- a/hasura/hasura-migrations/migrations/1575797453493_create_remote_schema_auth/up.yaml
+++ b/hasura/hasura-migrations/migrations/1575797453493_create_remote_schema_auth/up.yaml
@@ -4,5 +4,6 @@
       headers: []
       timeout_seconds: 60
       url: http://auth-server-service:8010/auth/graphql
+      # url: http://host.docker.internal:8010/auth/graphql
     name: auth
   type: add_remote_schema


### PR DESCRIPTION
Updated documentation for using `http://host.docker.internal` for hasura migrations on Mac.