### PR TITLE
Remove SI notation

### DIFF
--- a/front-end/src/components/Balance.tsx
+++ b/front-end/src/components/Balance.tsx
@@ -35,7 +35,7 @@ const Balance = ({ address }: Props) => {
 
 	return (
 		<div className='text-muted'>
-			{formatBalance(balance)} available
+			{formatBalance(balance, { withSi: false, withUnit: true })} available.
 		</div>
 	);
 };


### PR DESCRIPTION
this SI is particularly confusing IMO.
was:
![image](https://user-images.githubusercontent.com/33178835/77748757-2a0dca80-7021-11ea-866a-a8efd4721ad3.png)

now: 
![image](https://user-images.githubusercontent.com/33178835/77748778-342fc900-7021-11ea-9d97-2fac5d7c654c.png)

