### PR TITLE
Use total votes with multiplicators instead of turnout

### DIFF
--- a/front-end/src/components/Post/GovernanceSideBar/Referenda/ReferendumVoteInfo.tsx
+++ b/front-end/src/components/Post/GovernanceSideBar/Referenda/ReferendumVoteInfo.tsx
@@ -21,7 +21,7 @@ interface Props {
 const ReferendumVoteInfo = ({ className, referendumId, threshold }: Props) => {
 	const ZERO = new BN(0);
 	const { api, apiReady } = useContext(ApiContext);
-	const [totalVotes, setTotalVotes] = useState(ZERO);
+	const [turnout, setTurnout] = useState(ZERO);
 	const [electorate, setElectorate] = useState(ZERO);
 	const [passingThreshold, setPassingThreshold] = useState(ZERO);
 	const [ayeVotes, setAyeVotes] = useState(ZERO);
@@ -46,7 +46,7 @@ const ReferendumVoteInfo = ({ className, referendumId, threshold }: Props) => {
 			if (_info?.isOngoing){
 				setAyeVotes(_info?.asOngoing.tally.ayes);
 				setNayVotes(_info?.asOngoing.tally.nays);
-				setTotalVotes(_info?.asOngoing.tally.turnout);
+				setTurnout(_info?.asOngoing.tally.turnout);
 			}
 		})
 			.then( unsub => {unsubscribe = unsub;})
@@ -83,9 +83,9 @@ const ReferendumVoteInfo = ({ className, referendumId, threshold }: Props) => {
 			return;
 		}
 
-		const x = getPassingThreshold(nayVotes, electorate, totalVotes, threshold);
+		const x = getPassingThreshold(nayVotes, electorate, turnout, threshold);
 		setPassingThreshold(x);
-	}, [electorate, nayVotes, threshold, totalVotes]);
+	}, [electorate, nayVotes, threshold, turnout]);
 
 	return (
 		<Grid className={className} columns={3} divided>
@@ -93,12 +93,11 @@ const ReferendumVoteInfo = ({ className, referendumId, threshold }: Props) => {
 				ayeVotes={ayeVotes}
 				passingThreshold={passingThreshold}
 				nayVotes={nayVotes}
-				totalVotes={totalVotes}
 			/>
 			<Grid.Row>
 				<Grid.Column>
 					<h6>Turnout</h6>
-					<div>{formatBnBalance(totalVotes, { numberAfterComma: 2 })}</div>
+					<div>{formatBnBalance(turnout, { numberAfterComma: 2 })}</div>
 				</Grid.Column>
 				<Grid.Column width={5}>
 					<h6>Aye</h6>

--- a/front-end/src/ui-components/VoteProgress.tsx
+++ b/front-end/src/ui-components/VoteProgress.tsx
@@ -15,7 +15,6 @@ interface Props {
 	className?: string,
 	nayVotes: BN,
 	passingThreshold: BN,
-	totalVotes: BN,
 }
 
 const bnToIntBalance = function (bn: BN): number{
@@ -26,7 +25,7 @@ const bnToStringBalanceDelimitor = function (bn: BN): string{
 	return  formatBnBalance(bn, { numberAfterComma: 2, withThousandDelimitor: true });
 };
 
-const VoteProgress = ({ ayeVotes, className, nayVotes, passingThreshold, totalVotes }: Props) => {
+const VoteProgress = ({ ayeVotes, className, nayVotes, passingThreshold }: Props) => {
 	const network = getNetwork();
 	const tokenSymbol = chainProperties[network].tokenSymbol;
 
@@ -34,7 +33,7 @@ const VoteProgress = ({ ayeVotes, className, nayVotes, passingThreshold, totalVo
 	const passingThresholdNumber = bnToIntBalance(passingThreshold);
 	const isPassing = passingThreshold.lt(ayeVotes);
 	const ayeVotesNumber = bnToIntBalance(ayeVotes);
-	const totalVotesNumber = bnToIntBalance(totalVotes);
+	const totalVotesNumber = bnToIntBalance(ayeVotes.add(nayVotes));
 	const passingThresholdPercent = isPassing
 		? passingThresholdNumber/totalVotesNumber*100
 		: passingThresholdNumber/(passingThresholdNumber+nayVotesNumber)*100;


### PR DESCRIPTION
Fixing this:
![image](https://user-images.githubusercontent.com/33178835/78689189-56b1c400-78f6-11ea-8932-d12b834c6faa.png)

The current % in css is 140/132 -> 105%
It should be 140/366 (totalVotes is aye + nay with multiplicators)-> 38%