### PR TITLE
Fv change of docker registrie

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 image: parity/kubetools:helm3
 variables:
   KUBE_NAMESPACE:                  "polkassembly"
-  CI_REGISTRY:                     "gcr.io/test-installations-222013"
+  CI_REGISTRY:                     "paritytech"
   DOCKER_TAG:                      '$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA'
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,7 +102,7 @@ lint-chain-db-watcher:
     - export DOCKER_IMAGE="${CI_REGISTRY}/${KUBE_NAMESPACE}-${POD_NAME}"
     - export DOCKER_IMAGE_FULL_NAME=$DOCKER_IMAGE:$DOCKER_TAG
     - echo "$BUILD_ARGS"
-    - echo "$DOCKER_REGISTRY_JSON" | docker login -u _json_key --password-stdin https://gcr.io
+    - echo "$Docker_Hub_Pass_Parity" | docker login -u "$Docker_Hub_User_Parity" --password-stdin 
     - eval "docker build -t" "$DOCKER_IMAGE_FULL_NAME" "$BUILD_ARGS" "$POD_NAME"
     - docker push "$DOCKER_IMAGE_FULL_NAME"
 

--- a/kubernetes/polkassembly/auth-server-deployment.yaml
+++ b/kubernetes/polkassembly/auth-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: auth-server
-        image: gcr.io/test-installations-222013/polkassembly-auth-server:${DOCKER_TAG}
+        image: paritytech/polkassembly-auth-server:${DOCKER_TAG}
         imagePullPolicy: Always
         env:
         - name: JWT_KEY_PASSPHRASE

--- a/kubernetes/polkassembly/auth-server-deployment.yaml
+++ b/kubernetes/polkassembly/auth-server-deployment.yaml
@@ -101,5 +101,3 @@ spec:
       - name: cloudsql-instance-credentials
         secret:
           secretName: cloudsql-instance-credentials
-      imagePullSecrets:
-      - name: regcred

--- a/kubernetes/polkassembly/chain-db-watcher-deployment.yaml
+++ b/kubernetes/polkassembly/chain-db-watcher-deployment.yaml
@@ -75,5 +75,3 @@ spec:
             configMapKeyRef:
               key: START_FROM
               name: chain-db-watcher-config
-      imagePullSecrets:
-      - name: regcred

--- a/kubernetes/polkassembly/chain-db-watcher-deployment.yaml
+++ b/kubernetes/polkassembly/chain-db-watcher-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: chain-db-watcher
-        image: gcr.io/test-installations-222013/polkassembly-chain-db-watcher:${DOCKER_TAG}
+        image: paritytech/polkassembly-chain-db-watcher:${DOCKER_TAG}
         imagePullPolicy: Always
         env:
         - name: PROPOSAL_BOT_USERNAME

--- a/kubernetes/polkassembly/front-end-deployment.yaml
+++ b/kubernetes/polkassembly/front-end-deployment.yaml
@@ -23,6 +23,4 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-      imagePullSecrets:
-      - name: regcred
       restartPolicy: Always

--- a/kubernetes/polkassembly/front-end-deployment.yaml
+++ b/kubernetes/polkassembly/front-end-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: front-end
-        image: gcr.io/test-installations-222013/polkassembly-front-end:${DOCKER_TAG}
+        image: paritytech/polkassembly-front-end:${DOCKER_TAG}
         imagePullPolicy: Always
         ports:
         - containerPort: 80


### PR DESCRIPTION
 DevOps Team decided to limit the number of Docker Registries to maintain to only two, so we have to 'abandon' GCR in *test-installations* project in favour of `paritytech` reg at [docker.com](https://hub.docker.com/u/paritytech).

Please keep in mind, that the new registry is publicly available, so no more k8s `pullSecrets` or other means of authentication required to download the images. Just to state the obvious: We have to be even more careful not to include any private/secret information into the images.