### PR TITLE
Fv fix prod depl with helm

### DIFF
--- a/kubernetes/polkassembly/templates/auth-server-config.yaml
+++ b/kubernetes/polkassembly/templates/auth-server-config.yaml
@@ -8,7 +8,3 @@ data:
   {{- range $key, $val := .Values.authServer.config }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
-{{- with .Values.nodeSelector }}
-nodeSelector:
-{{ toYaml . | indent 2 }}
-{{- end }}

--- a/kubernetes/polkassembly/templates/chain-db-watcher-config.yaml
+++ b/kubernetes/polkassembly/templates/chain-db-watcher-config.yaml
@@ -8,7 +8,3 @@ data:
   {{- range $key, $val := .Values.chainDbWatcher.config }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
-{{- with .Values.nodeSelector }}
-nodeSelector:
-{{ toYaml . | indent 2 }}
-{{- end }}

--- a/kubernetes/polkassembly/templates/hasura-config.yaml
+++ b/kubernetes/polkassembly/templates/hasura-config.yaml
@@ -8,7 +8,3 @@ data:
   {{- range $key, $val := .Values.hasura.config }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
-{{- with .Values.nodeSelector }}
-nodeSelector:
-{{ toYaml . | indent 2 }}
-{{- end }}

--- a/kubernetes/polkassembly/values-dashboards-cluster-1.yaml
+++ b/kubernetes/polkassembly/values-dashboards-cluster-1.yaml
@@ -1,4 +1,4 @@
-# Default values for polkassembly.
+# DASHBOARDS-CLUSTER-1 values for polkassembly.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 

--- a/kubernetes/polkassembly/values-parity-prod.yaml
+++ b/kubernetes/polkassembly/values-parity-prod.yaml
@@ -1,4 +1,4 @@
-# Default values for polkassembly.
+# PARITY-PROD values for polkassembly.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 


### PR DESCRIPTION
this fixes the prod deployment. the newly introduced
```
      nodeSelector:
        cloud.google.com/gke-nodepool: apps-pool
```
statement will bind our deployments to it's own node-pool, so our pods run on dedicated hardware within the *parity-prod* k8s cluster.

this only needs to be attached to `kind: deployment` objects, so i had to remove it from the `configmaps`. 