### PR TITLE
Prevent motions following a treasury to be continuously reassigned

### DIFF
--- a/chain-db-watcher/src/types.ts
+++ b/chain-db-watcher/src/types.ts
@@ -54,6 +54,8 @@ export interface DiscussionSyncMap {
     treasuryProposals?: ObjectMap;
 }
 
+export type TreasuryDeduplicateMotionMap = Record< number, number[]>;
+
 export type ObjectMap = {[index: string]: string};
 export type MotionObjectMap = {[index: string]: OnchainMotionSyncType};
 export type ReferendumObjectMap = {[index: string]: OnchainReferendaValueSyncType};

--- a/chain-db-watcher/src/types.ts
+++ b/chain-db-watcher/src/types.ts
@@ -54,7 +54,7 @@ export interface DiscussionSyncMap {
     treasuryProposals?: ObjectMap;
 }
 
-export type TreasuryDeduplicateMotionMap = Record< number, number[]>;
+export type TreasuryDeduplicateMotionMap = Record<number, number[]>;
 
 export type ObjectMap = {[index: string]: string};
 export type MotionObjectMap = {[index: string]: OnchainMotionSyncType};


### PR DESCRIPTION
 closes #536 

Here is a log of `treasuryDeduplicatedMotionsMap` running on test starting from block 1100000
```bash
treasuryDeduplicatedMotionsMap {
  "12": [
    103,
    104
  ],
  "14": [
    126,
    128
  ],
  "15": [
    127,
    129
  ]
}
```

We can see that we have 3 treasury proposal that have all 2 motions attached to it.
Chain-db watcher will now only care about the highest motion. This has the positive effect of not constantly reassigning the motions (before it kept assigning treasury 15 to motion 127, then to 129, then to 127.. at each launch, now it'll pick 129 and only reassign treasury 15 if there's another motion). The negative side effect is that navigating to polkassembly.io/motion/127, this id isn't in hasura. Note that this is not new, and not because of this PR (just navigate to https://kusama.polkassembly.io/motion/127 you'll see).

This should be addressed in another PR. This will most probably need to be a new table in hasura to track reassigned treasury proposals, and make a redirection, so that motion/127 redirects to motion/129.

ps: chain-db-watcher is getting convoluted :( I tried my best to comment and go step by step, there might be better ways to do what I did.