### PR TITLE
pin docker-in-docker image to version 18, v19 has breaking change

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,9 +93,9 @@ lint-chain-db-watcher:
     DOCKER_HOST: tcp://localhost:2375
   tags:
     - kubernetes-parity-build
-  image: docker:git
+  image: docker:18-git
   services:
-    - docker:dind
+    - docker:18-dind
   script:
     - POD_NAME=$(echo ${CI_JOB_NAME} | sed -E 's/^[[:alnum:]:]+-//')
     - export DOCKER_IMAGE="${CI_REGISTRY}/${KUBE_NAMESPACE}-${POD_NAME}"


### PR DESCRIPTION
Looks like using the latest *docker* docker-image from dockerhub, that we use in our dockerize stage is braking our pipeline. More info [here](https://github.com/paritytech/devops/issues/479#issuecomment-618292033), untli we know how to fix it we use the version 18 of the image.