### PR TITLE
Comment box width fix

### DIFF
--- a/front-end/src/components/Comment/Comment.tsx
+++ b/front-end/src/components/Comment/Comment.tsx
@@ -99,6 +99,7 @@ export default styled(Comment)`
 		border-radius: 3px;
 		margin-bottom: 1rem;
 		width: 100%;
+		word-break: break-word;
 
 		@media only screen and (max-width: 576px) {
 			width: 100%;


### PR DESCRIPTION
Closes #706

Before
<img width="871" alt="Screenshot 2020-04-24 at 15 52 42" src="https://user-images.githubusercontent.com/7072141/80220128-ae189980-8643-11ea-8671-c126f6362b69.png">

After
<img width="807" alt="Screenshot 2020-04-24 at 15 52 48" src="https://user-images.githubusercontent.com/7072141/80220137-b1138a00-8643-11ea-8e1a-50fa35b6c2b8.png">

