### PR TITLE
Add retry mechanism to chain-db-watcher getToken

### DIFF
--- a/chain-db-watcher/package.json
+++ b/chain-db-watcher/package.json
@@ -56,6 +56,7 @@
     "graphql-request": "^1.8.2",
     "graphql-tag": "^2.10.1",
     "node-fetch": "^2.6.0",
+    "p-retry": "^4.2.0",
     "subscriptions-transport-ws": "^0.9.16",
     "ts-node": "^8.6.1",
     "typescript": "^3.8.3",

--- a/chain-db-watcher/src/graphql_helpers.ts
+++ b/chain-db-watcher/src/graphql_helpers.ts
@@ -33,11 +33,11 @@ const DEFAULT_DESCRIPTION = 'The title and description of this proposal can only
 
 const getTokenRetried = async (): Promise<string | void> => {
 	if (!discussionGraphqlUrl) {
-		throw new Error('Environment variable for the REACT_APP_HASURA_GRAPHQL_URL not set.');
+		throw new pRetry.AbortError('Environment variable for the REACT_APP_HASURA_GRAPHQL_URL not set.');
 	}
 
 	if (!proposalBotPassword || !proposalBotUsername) {
-		throw new Error(
+		throw new pRetry.AbortError(
 			"PROPOSAL_BOT_USERNAME or PROPOSAL_BOT_PASSWORD environment variables haven't been set for the proposal bot to login."
 		);
 	}
@@ -49,7 +49,7 @@ const getTokenRetried = async (): Promise<string | void> => {
 	if (data.login?.token) {
 		return data?.login?.token;
 	} else {
-		throw new Error(`Unexpected data at proposal bot login: ${data}`);
+		throw new pRetry.AbortError(`Unexpected data at proposal bot login: ${data}`);
 	}
 };
 

--- a/chain-db-watcher/src/graphql_helpers.ts
+++ b/chain-db-watcher/src/graphql_helpers.ts
@@ -33,12 +33,14 @@ const DEFAULT_DESCRIPTION = 'The title and description of this proposal can only
 
 const getTokenRetried = async (): Promise<string | void> => {
 	if (!discussionGraphqlUrl) {
-		throw new pRetry.AbortError('Environment variable for the REACT_APP_HASURA_GRAPHQL_URL not set.');
+		throw new pRetry.AbortError(
+			new Error('Environment variable for the REACT_APP_HASURA_GRAPHQL_URL not set.')
+		);
 	}
 
 	if (!proposalBotPassword || !proposalBotUsername) {
 		throw new pRetry.AbortError(
-			"PROPOSAL_BOT_USERNAME or PROPOSAL_BOT_PASSWORD environment variables haven't been set for the proposal bot to login."
+			new Error("PROPOSAL_BOT_USERNAME or PROPOSAL_BOT_PASSWORD environment variables haven't been set for the proposal bot to login.")
 		);
 	}
 
@@ -49,7 +51,9 @@ const getTokenRetried = async (): Promise<string | void> => {
 	if (data.login?.token) {
 		return data?.login?.token;
 	} else {
-		throw new pRetry.AbortError(`Unexpected data at proposal bot login: ${data}`);
+		throw new pRetry.AbortError(
+			new Error(`Unexpected data at proposal bot login: ${data}`)
+		);
 	}
 };
 

--- a/chain-db-watcher/yarn.lock
+++ b/chain-db-watcher/yarn.lock
@@ -965,6 +965,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/retry@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
 "@types/valid-url@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/valid-url/-/valid-url-1.0.2.tgz#60fa435ce24bfd5ba107b8d2a80796aeaf3a8f45"
@@ -3907,6 +3912,14 @@ p-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
 
+p-retry@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.2.0.tgz#ea9066c6b44f23cab4cd42f6147cdbbc6604da5d"
+  integrity sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==
+  dependencies:
+    "@types/retry" "^0.12.0"
+    retry "^0.12.0"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
@@ -4290,6 +4303,11 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
 reusify@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
closes #557 

Tested various scenarios including when the auth server everntually goes online, it then prints something like:
```bash
# ... errors
ConnectionFailure Network.Socket.connect: <socket: 41>: does not exist (Connection refused): {"response":{"errors":[{"extensions":{"path":"$","code":"unexpected"},"message":"ConnectionFailure Network.Socket.connect: <socket: 41>: does not exist (Connection refused)"}],"status":200},"request":{"query":"mutation loginMutation($password: String!, $username: String!) {\n  login(password: $password, username: $username) {\n    token\n  }\n}\n","variables":{"password":"botbot","username":"botbot"}}} 
🤞 retyring, attempt 4/11.
✔︎ Proposal 0 added to the database.
✔︎ Proposal 2 added to the database.
✔︎ Proposal 1 added to the database.
✔︎ Treasury proposal 0 added to the database.
✔︎ Motion id 1 linked to treasury proposal id 0.
✔︎ Motion 0 added to the database.
No democracy proposal tabled at block 540. It must have been initiated by a council motion.
✔︎ Referendum id 2 added to the onchain_links with proposal id 1.
✔︎ Referendum id 0 added to the onchain_links with proposal id 0.
✔︎ Referendum id 1 added to the onchain_links with motion id 0.
✅ Syncing finished.
🚀 Chain-db watcher listening to http://localhost:4466/ from block 0
---> Connecting...
---> Connected
```