### PR TITLE
GH Footer link warning fix

### DIFF
--- a/front-end/src/components/Footer/index.tsx
+++ b/front-end/src/components/Footer/index.tsx
@@ -13,10 +13,7 @@ interface Props {
 }
 
 const Footer = ({ className }:Props ): JSX.Element => {
-	const navigateToIssues = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-		event.preventDefault();
-		window.open('https://github.com/paritytech/polkassembly/issues', '_blank');
-	};
+
 	return (
 		<footer className={className}>
 			<Menu>
@@ -32,8 +29,10 @@ const Footer = ({ className }:Props ): JSX.Element => {
 				<Menu.Item as={Link} to="/privacy">
 					Privacy Policy
 				</Menu.Item>
-				<Menu.Item as={Link} onClick={navigateToIssues} to=''>
-					Report an Issue
+				<Menu.Item>
+					<a className='item' href='https://github.com/paritytech/polkassembly/issues' target='blank'>
+						Report an Issue
+					</a>
 				</Menu.Item>
 			</Menu>
 		</footer>
@@ -41,30 +40,30 @@ const Footer = ({ className }:Props ): JSX.Element => {
 };
 
 export default styled(Footer)`
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-    height: 4rem;
+	position: absolute;
+	bottom: 0;
+	width: 100%;
+	height: 4rem;
 
-    .ui.menu {
-        background-color: black_full;
-        font-family: font_default;
-        padding: 1rem 3rem;
-        border-radius: 0rem;
-        height: 100%;
+	.ui.menu {
+		background-color: black_full;
+		font-family: font_default;
+		padding: 1rem 3rem;
+		border-radius: 0rem;
+		height: 100%;
 
-        .item {
-            color: grey_secondary;
+		.item {
+			color: grey_secondary;
 			font-size: sm;
 			padding: 1rem;
-            &:hover {
-                color: white;
-            }
-        }
+			&:hover {
+				color: white;
+			}
+		}
 
-        @media only screen and (max-width: 768px)  {
-            flex-direction: column;
-            height: auto;
-        }
-    }
+		@media only screen and (max-width: 768px)  {
+			flex-direction: column;
+			height: auto;
+		}
+	}
 `;

--- a/front-end/src/components/Footer/index.tsx
+++ b/front-end/src/components/Footer/index.tsx
@@ -32,7 +32,7 @@ const Footer = ({ className }:Props ): JSX.Element => {
 				<Menu.Item as={Link} to="/privacy">
 					Privacy Policy
 				</Menu.Item>
-				<Menu.Item as={Link} onClick={navigateToIssues}>
+				<Menu.Item as={Link} onClick={navigateToIssues} to=''>
 					Report an Issue
 				</Menu.Item>
 			</Menu>


### PR DESCRIPTION
This sneaked in with #725
<img width="776" alt="Screenshot 2020-04-28 at 16 27 40" src="https://user-images.githubusercontent.com/7072141/80499757-aa4f8480-896d-11ea-880e-c8a8b40c2a0b.png"> 