### PR TITLE
Web3 Signup Styling

### DIFF
--- a/front-end/src/components/Signup/Web2Signup.tsx
+++ b/front-end/src/components/Signup/Web2Signup.tsx
@@ -142,11 +142,11 @@ const SignupForm = ({ className, toggleWeb2Signup }:Props): JSX.Element => {
 						ref={register({ required: true })}
 						type='checkbox'
 					/>
-					{' '}I have read and agree to the terms of the <Link to='/terms-and-conditions'>Polkassembly end user agreement</Link>.
+					I have read and agree to the terms of the <Link to='/terms-and-conditions'>Polkassembly end user agreement</Link>.
 				</label>
 				{errors.termsandconditions && <div className={'errorText'}>Please agree to the terms of the Polkassembly end user agreement.</div>}
 			</Form.Field>
-			<div>To see how we use your personal data please see our <Link to='/privacy'>privacy notice</Link>.</div>
+			<div className='text-muted'>To see how we use your personal data please see our <Link to='/privacy'>privacy notice</Link>.</div>
 			<div className={'mainButtonContainer'}>
 				<Button
 					primary
@@ -176,15 +176,6 @@ const SignupForm = ({ className, toggleWeb2Signup }:Props): JSX.Element => {
 
 export default styled(SignupForm)`
 
-	a {
-			color: grey_primary;
-			border-bottom-style: solid;
-			border-bottom-width: 1px;
-			border-bottom-color: grey_primary;
-		}
-	sup {
-		color: grey_primary;
-	}
 	.mainButtonContainer{
 		align-items: center;
 		display: flex;
@@ -208,12 +199,11 @@ export default styled(SignupForm)`
 		font-size: sm !important;
 		font-weight: 400 !important;
 		color: grey_primary !important;
-	}
-
-	.ui.form input[type=checkbox]{
-		position: relative;
-		bottom: 0.2rem;
-		margin-right: 1rem;
-		vertical-align: middle;
+		a {
+			color: grey_primary;
+			border-bottom-style: solid;
+			border-bottom-width: 1px;
+			border-bottom-color: grey_primary;
+		}
 	}
 `;

--- a/front-end/src/components/Signup/Web3Signup.tsx
+++ b/front-end/src/components/Signup/Web3Signup.tsx
@@ -221,11 +221,11 @@ const SignupForm = ({ className, toggleWeb2Signup }:Props): JSX.Element => {
 								ref={register({ required: true })}
 								type='checkbox'
 							/>
-							{' '}I have read and agree to the terms of the <Link to='/terms-and-conditions'>Polkassembly end user agreement</Link>.
+							I have read and agree to the terms of the <Link to='/terms-and-conditions'>Polkassembly end user agreement</Link>.
 						</label>
 						{errors.termsandconditions && <div className={'errorText'}>Please agree to the terms of the Polkassembly end user agreement.</div>}
 					</Form.Field>
-					<div className='privacy'>To see how we use your personal data please see our <Link to='/privacy'>privacy notice</Link>.</div>
+					<div className='text-muted'>To see how we use your personal data please see our <Link to='/privacy'>privacy notice</Link>.</div>
 					<div className={'mainButtonContainer'}>
 						<Button
 							primary
@@ -260,6 +260,7 @@ export default styled(SignupForm)`
 		display: flex;
 		flex-direction: row;
 		justify-content: center;
+		margin-top: 3rem;
 	}
 
 	input.error {
@@ -276,11 +277,22 @@ export default styled(SignupForm)`
 		color: red_secondary;
 	}
 
-	.ui.dimmer {
-		height: calc(100% - 6.5rem);
+	.checkbox-label {
+		position: relative;
+		bottom: 0.1rem;
+		display: inline-block !important;
+		font-size: sm !important;
+		font-weight: 400 !important;
+		color: grey_primary !important;
+		a {
+			color: grey_primary;
+			border-bottom-style: solid;
+			border-bottom-width: 1px;
+			border-bottom-color: grey_primary;
+		}
 	}
 
-	.privacy {
-		margin-bottom: 10px;
+	.ui.dimmer {
+		height: calc(100% - 6.5rem);
 	}
 `;

--- a/front-end/src/ui-components/Form.tsx
+++ b/front-end/src/ui-components/Form.tsx
@@ -26,7 +26,6 @@ export function Form({ className, standalone=true, ...props } : FormProps): Reac
 const StyledForm = styled(SUIForm)`
 	&.standalone {
 		background-color: white;
-		margin-top: 2rem;
 		padding: 2rem 3rem 3rem 3rem;
 		border-style: solid;
 		border-width: 1px;
@@ -107,6 +106,13 @@ const StyledForm = styled(SUIForm)`
 		input::selection, textarea::selection {
 			color: black_text;
 			background-color: grey_light;
+		}
+
+		input[type=checkbox]{
+			position: relative;
+			bottom: 0.2rem;
+			margin-right: 1rem;
+			vertical-align: middle;
 		}
 
 		@media only screen and (max-width: 576px) {


### PR DESCRIPTION
Styling for web3 signup #724 
<img width="1383" alt="Screenshot 2020-04-28 at 22 30 47" src="https://user-images.githubusercontent.com/7072141/80534974-59a54f00-89a0-11ea-9133-88a10b910593.png">
<img width="1388" alt="Screenshot 2020-04-28 at 22 31 03" src="https://user-images.githubusercontent.com/7072141/80534984-5d38d600-89a0-11ea-8810-52939493f3a8.png">

Just thinking out loud: the 'Sign Up With Web3' button is just about visible at the bottom of the page. Wondering if we should have Display Name input only appear when typing into username field to make the form shorter.