### PR TITLE
Automate draft release publication 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,8 +128,6 @@ dockerize:production-front-end:
     - export BUILD_ARGS="--build-arg REACT_APP_HASURA_GRAPHQL_URL=$(printf \"$PRODUCTION_REACT_APP_HASURA_GRAPHQL_URL\")"
     - export BUILD_ARGS="$BUILD_ARGS --build-arg REACT_APP_JWT_PUBLIC_KEY=$(printf "%s" \'"$PRODUCTION_REACT_APP_JWT_PUBLIC_KEY"\')"
   only:
-    - master
-    - tags
     - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
   <<: *build_and_push
 
@@ -139,7 +137,7 @@ dockerize-auth-server:
     name: parity-build
   only:
     - master
-    - tags
+    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
   <<: *build_and_push
 
 dockerize-chain-db-watcher:
@@ -148,7 +146,7 @@ dockerize-chain-db-watcher:
     name: parity-build
   only:
     - master
-    - tags
+    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
   <<: *build_and_push
 
 #### stage:                        deploy
@@ -216,8 +214,6 @@ deploy-production:
   tags:
     - kubernetes-parity-build
   only:
-    - master
-    - tags
     - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
   <<: *deploy-k8s
 
@@ -227,8 +223,6 @@ publish-draft-release:
     name: parity-prod
   image: parity/tools:latest
   only:
-    - master
-    - tags
     - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
   script:
     - ./.maintain/publish_draft_release.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,7 @@ stages:
   - test
   - dockerize
   - deploy
+  - publish
 
 cache:
   key:                             '${CI_JOB_NAME}'
@@ -214,4 +215,17 @@ deploy-production:
     - kubernetes-parity-build
   only:
     - tags
-  <<: *deploy-k8s
+    - /^release-v[0-9]+\.[0-9]+\.[0-9]+$/        # i.e. release-v1.0.1
+
+publish-draft-release:
+  stage: deploy
+  environment:
+    name: parity-prod
+  image: parity/tools:latest
+  only:
+    - tags
+    - /^release-v[0-9]+\.[0-9]+\.[0-9]+$/        # i.e. release-v1.0.1
+  script:
+    - ./.maintain/publish_draft_release.sh
+  interruptible:                   true
+  allow_failure:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,7 @@ stages:
   - test
   - dockerize
   - deploy
+  - publish
 
 cache:
   key:                             '${CI_JOB_NAME}'
@@ -115,9 +116,6 @@ dockerize:staging-front-end:
   before_script:
     - export BUILD_ARGS="--build-arg REACT_APP_HASURA_GRAPHQL_URL=$(printf \"$STAGING_REACT_APP_HASURA_GRAPHQL_URL\")"
     - export BUILD_ARGS="$BUILD_ARGS --build-arg REACT_APP_JWT_PUBLIC_KEY=$(printf "%s" \'"$STAGING_REACT_APP_JWT_PUBLIC_KEY"\')"
-  rules:
-    - changes:
-      - "front-end/**/*"
   only:
     - master
   <<: *build_and_push
@@ -130,16 +128,15 @@ dockerize:production-front-end:
     - export BUILD_ARGS="--build-arg REACT_APP_HASURA_GRAPHQL_URL=$(printf \"$PRODUCTION_REACT_APP_HASURA_GRAPHQL_URL\")"
     - export BUILD_ARGS="$BUILD_ARGS --build-arg REACT_APP_JWT_PUBLIC_KEY=$(printf "%s" \'"$PRODUCTION_REACT_APP_JWT_PUBLIC_KEY"\')"
   only:
+    - master
     - tags
+    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
   <<: *build_and_push
 
 dockerize-auth-server:
   stage: dockerize
   environment:
     name: parity-build
-  rules:
-    - changes:
-      - "auth-server/**/*"
   only:
     - master
     - tags
@@ -149,9 +146,6 @@ dockerize-chain-db-watcher:
   stage: dockerize
   environment:
     name: parity-build
-  rules:
-    - changes:
-      - "chain-db-watcher/**/*"
   only:
     - master
     - tags
@@ -222,17 +216,20 @@ deploy-production:
   tags:
     - kubernetes-parity-build
   only:
+    - master
     - tags
-    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/        # i.e. v1.0.1, v1.0.1-beta
+    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
+  <<: *deploy-k8s
 
 publish-draft-release:
-  stage: deploy
+  stage: publish
   environment:
     name: parity-prod
   image: parity/tools:latest
   only:
+    - master
     - tags
-    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/        # i.e. v1.0.1, v1.0.1-beta
+    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
   script:
     - ./.maintain/publish_draft_release.sh
   interruptible:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,16 +215,16 @@ deploy-production:
     - kubernetes-parity-build
   only:
     - tags
-    - /^release-v[0-9]+\.[0-9]+\.[0-9]+$/        # i.e. release-v1.0.1
+    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/        # i.e. v1.0.1, v1.0.1-beta
 
 publish-draft-release:
-  stage: deploy
+  stage: publish
   environment:
     name: parity-prod
   image: parity/tools:latest
   only:
     - tags
-    - /^release-v[0-9]+\.[0-9]+\.[0-9]+$/        # i.e. release-v1.0.1
+    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/        # i.e. v1.0.1, v1.0.1-beta
   script:
     - ./.maintain/publish_draft_release.sh
   interruptible:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,6 @@ stages:
   - test
   - dockerize
   - deploy
-  - publish
 
 cache:
   key:                             '${CI_JOB_NAME}'
@@ -116,6 +115,9 @@ dockerize:staging-front-end:
   before_script:
     - export BUILD_ARGS="--build-arg REACT_APP_HASURA_GRAPHQL_URL=$(printf \"$STAGING_REACT_APP_HASURA_GRAPHQL_URL\")"
     - export BUILD_ARGS="$BUILD_ARGS --build-arg REACT_APP_JWT_PUBLIC_KEY=$(printf "%s" \'"$STAGING_REACT_APP_JWT_PUBLIC_KEY"\')"
+  rules:
+    - changes:
+      - "front-end/**/*"
   only:
     - master
   <<: *build_and_push
@@ -135,6 +137,9 @@ dockerize-auth-server:
   stage: dockerize
   environment:
     name: parity-build
+  rules:
+    - changes:
+      - "auth-server/**/*"
   only:
     - master
     - tags
@@ -144,6 +149,9 @@ dockerize-chain-db-watcher:
   stage: dockerize
   environment:
     name: parity-build
+  rules:
+    - changes:
+      - "chain-db-watcher/**/*"
   only:
     - master
     - tags
@@ -218,7 +226,7 @@ deploy-production:
     - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/        # i.e. v1.0.1, v1.0.1-beta
 
 publish-draft-release:
-  stage: publish
+  stage: deploy
   environment:
     name: parity-prod
   image: parity/tools:latest

--- a/.maintain/generate_changelog.sh
+++ b/.maintain/generate_changelog.sh
@@ -1,18 +1,13 @@
 #!/usr/bin/env bash
 
-echo "-- hi"
 # shellcheck source=lib.sh
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/lib.sh"
 
 version="$2"
 last_version="$1"
 
-echo "bla   $version .. $last_version"
-
 all_changes="$(sanitised_git_logs "$last_version" "$version")"
-echo "all_changes: $all_changes"
 fix_changes=""
-api_changes=""
 feature_changes=""
 changes=""
 
@@ -38,19 +33,19 @@ Polkassembly changes
 
 EOF
 )
-  if [ -n "$fix_changes" ]; then
-    changes="$changes
-
-Fixes
--------
-$fix_changes"
-  fi
   if [ -n "$feature_changes" ]; then
     changes="$changes
 
 Features
 ------
 $feature_changes"
+  fi
+  if [ -n "$fix_changes" ]; then
+    changes="$changes
+
+Fixes
+-------
+$fix_changes"
   fi
   release_text="$release_text
 

--- a/.maintain/generate_changelog.sh
+++ b/.maintain/generate_changelog.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+echo "-- hi"
+# shellcheck source=lib.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/lib.sh"
+
+version="$2"
+last_version="$1"
+
+echo "bla   $version .. $last_version"
+
+all_changes="$(sanitised_git_logs "$last_version" "$version")"
+echo "all_changes: $all_changes"
+fix_changes=""
+api_changes=""
+feature_changes=""
+changes=""
+
+while IFS= read -r line; do
+  pr_id=$(echo "$line" | sed -E 's/.*#([0-9]+)\)$/\1/')
+
+  if has_label 'paritytech/polkassembly' "$pr_id" 'x- changelog-fix'; then
+    fix_changes="$fix_changes
+$line"
+  fi
+  if has_label 'paritytech/polkassembly' "$pr_id" 'x- changelog-feature'; then
+    feature_changes="$feature_changes
+$line"
+  fi
+done <<< "$all_changes"
+
+# Make the polkassembly section if there are any polkassembly changes
+if [ -n "$fix_changes" ] ||
+   [ -n "$feature_changes" ]; then
+  changes=$(cat << EOF
+Polkassembly changes
+-----------------
+
+EOF
+)
+  if [ -n "$fix_changes" ]; then
+    changes="$changes
+
+Fixes
+-------
+$fix_changes"
+  fi
+  if [ -n "$feature_changes" ]; then
+    changes="$changes
+
+Features
+------
+$feature_changes"
+  fi
+  release_text="$release_text
+
+$changes"
+fi
+
+echo "$changes"

--- a/.maintain/lib.sh
+++ b/.maintain/lib.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+api_base="https://api.github.com/repos"
+
+# Function to take 2 git tags/commits and get any lines from commit messages
+# that contain something that looks like a PR reference: e.g., (#1234)
+sanitised_git_logs(){
+  git --no-pager log --pretty=format:"%s" "$1..$2" |
+  # Only find messages referencing a PR
+  grep -E '\(#[0-9]+\)' |
+  # Strip any asterisks
+  sed 's/^* //g' |
+  # And add them all back
+  sed 's/^/* /g'
+}
+
+# Returns the last published release on github
+# Note: we can't just use /latest because that ignores prereleases
+# repo: 'organization/repo'
+# Usage: last_github_release "$repo"
+last_github_release(){
+  i=0
+  # Iterate over releases until we find the last release that's not just a draft
+  while [ $i -lt 29 ]; do
+    out=$(curl -H "Authorization: token $GITHUB_RELEASE_TOKEN" -s "$api_base/$1/releases" | jq ".[$i]")
+    # echo "$out"
+    # Ugh when echoing to jq, we need to translate newlines into spaces :/
+    if [ "$(echo "$out" | tr '\r\n' ' ' | jq '.draft')" = "false" ]; then
+      echo "$out" | tr '\r\n' ' ' | jq '.tag_name' | sed 's/"//g'
+      return
+    else
+      i=$((i + 1))
+    fi
+  done
+}
+
+# Checks whether a tag on github has been verified
+# repo: 'organization/repo'
+# tagver: 'v1.2.3'
+# Usage: check_tag $repo $tagver
+check_tag () {
+  repo=$1
+  tagver=$2
+  tag_out=$(curl -H "Authorization: token $GITHUB_RELEASE_TOKEN" -s "$api_base/$repo/git/refs/tags/$tagver")
+  tag_sha=$(echo "$tag_out" | jq -r .object.sha)
+  object_url=$(echo "$tag_out" | jq -r .object.url)
+  if [ "$tag_sha" = "null" ]; then
+    return 2
+  fi
+  verified_str=$(curl -H "Authorization: token $GITHUB_RELEASE_TOKEN" -s "$object_url" | jq -r .verification.verified)
+  if [ "$verified_str" = "true" ]; then
+    # Verified, everything is good
+    return 0
+  else
+    # Not verified. Bad juju.
+    return 1
+  fi
+}
+
+# Checks whether a given PR has a given label.
+# repo: 'organization/repo'
+# pr_id: 12345
+# label: B1-silent
+# Usage: has_label $repo $pr_id $label
+has_label(){
+  repo="$1"
+  pr_id="$2"
+  label="$3"
+  out=$(curl -H "Authorization: token $GITHUB_RELEASE_TOKEN" -s "$api_base/$repo/pulls/$pr_id")
+  [ -n "$(echo "$out" | jq ".labels | .[] | select(.name==\"$label\")")" ]
+}
+
+# Formats a message into a JSON string for posting to Matrix
+# message: 'any plaintext message'
+# formatted_message: '<strong>optional message formatted in <em>html</em></strong>' 
+# Usage: structure_message $content $formatted_content (optional)
+structure_message() {
+  if [ -z "$2" ]; then
+    body=$(jq -Rs --arg body "$1" '{"msgtype": "m.text", $body}' < /dev/null)
+  else
+    body=$(jq -Rs --arg body "$1" --arg formatted_body "$2" '{"msgtype": "m.text", $body, "format": "org.matrix.custom.html", $formatted_body}' < /dev/null)
+  fi
+  echo "$body"
+}
+
+# Post a message to a matrix room
+# body: '{body: "JSON string produced by structure_message"}'
+# room_id: !fsfSRjgjBWEWffws:matrix.parity.io
+# access_token: see https://matrix.org/docs/guides/client-server-api/
+# Usage: send_message $body (json formatted) $room_id $access_token
+send_message() {
+curl -XPOST -d "$1" "https://matrix.parity.io/_matrix/client/r0/rooms/$2/send/m.room.message?access_token=$3"
+}

--- a/.maintain/publish_draft_release.sh
+++ b/.maintain/publish_draft_release.sh
@@ -48,6 +48,5 @@ formatted_msg_body=$(cat <<EOF
 Draft release created: $html_url
 EOF
 )
-# send_message "$(structure_message "$msg_body" "$formatted_msg_body")" "$MATRIX_ROOM_ID" "$MATRIX_ACCESS_TOKEN"
 
 echo "[+] Done! Maybe the release worked..."

--- a/.maintain/publish_draft_release.sh
+++ b/.maintain/publish_draft_release.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# shellcheck source=lib.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/lib.sh"
+
+version="$CI_COMMIT_TAG"
+
+# Note that this is not the last *tagged* version, but the last *published* version
+last_version=$(last_github_release 'paritytech/polkassembly')
+echo "last version version: $last_version $version"
+release_text="$(./generate_changelog.sh $last_version $version)"
+echo "release_text $release_text"
+echo "[+] Pushing release to github"
+# Create release on github
+release_name="Polkassembly $version"
+data=$(jq -Rs --arg version "$version" \
+  --arg release_name "$release_name" \
+  --arg release_text "$release_text" \
+'{
+  "tag_name": $version,
+  "target_commitish": "master",
+  "name": $release_name,
+  "body": $release_text,
+  "draft": true,
+  "prerelease": false
+}' < /dev/null)
+
+# out=$(curl -s -X POST --data "$data" -H "Authorization: token $GITHUB_RELEASE_TOKEN" "$api_base/paritytech/polkassembly/releases")
+
+html_url=$(echo "$out" | jq -r .html_url)
+
+if [ "$html_url" == "null" ]
+then
+  echo "[!] Something went wrong posting:"
+  echo "$out"
+else
+  echo "[+] Release draft created: $html_url"
+fi
+
+echo '[+] Sending draft release URL to Matrix'
+
+msg_body=$(cat <<EOF
+**Release pipeline for Polkassembly $version complete.**
+Draft release created: $html_url
+EOF
+)
+formatted_msg_body=$(cat <<EOF
+<strong>Release pipeline for Polkassembly $version complete.</strong><br />
+Draft release created: $html_url
+EOF
+)
+# send_message "$(structure_message "$msg_body" "$formatted_msg_body")" "$MATRIX_ROOM_ID" "$MATRIX_ACCESS_TOKEN"
+
+echo "[+] Done! Maybe the release worked..."

--- a/.maintain/publish_draft_release.sh
+++ b/.maintain/publish_draft_release.sh
@@ -7,9 +7,8 @@ version="$CI_COMMIT_TAG"
 
 # Note that this is not the last *tagged* version, but the last *published* version
 last_version=$(last_github_release 'paritytech/polkassembly')
-echo "last version version: $last_version $version"
-release_text="$(./generate_changelog.sh $last_version $version)"
-echo "release_text $release_text"
+release_text="$(GITHUB_RELEASE_TOKEN="$GITHUB_RELEASE_TOKEN" ./generate_changelog.sh "$last_version" "$version")"
+
 echo "[+] Pushing release to github"
 # Create release on github
 release_name="Polkassembly $version"
@@ -25,7 +24,7 @@ data=$(jq -Rs --arg version "$version" \
   "prerelease": false
 }' < /dev/null)
 
-# out=$(curl -s -X POST --data "$data" -H "Authorization: token $GITHUB_RELEASE_TOKEN" "$api_base/paritytech/polkassembly/releases")
+out=$(curl -s -X POST --data "$data" -H "Authorization: token $GITHUB_RELEASE_TOKEN" "$api_base/paritytech/polkassembly/releases")
 
 html_url=$(echo "$out" | jq -r .html_url)
 


### PR DESCRIPTION
closes #676 
- adds a publish stage to publish the draft release, thanks to @s3krit for the scripts!
- restricts production front-building and deployment to vx.y.z tags
- I've added `GITHUB_RELEASE_TOKEN`  as Gitlab secret in `parity_prod`. The other expected variable is `CI_COMMIT_TAG`.
- we'll tag any new PR with `x-changelog-(fix|release)` to get it into the change log.