### PR TITLE
Prevent a threshold wrongly placed when the api isn't loaded.

### DIFF
--- a/front-end/src/ui-components/VoteProgress.tsx
+++ b/front-end/src/ui-components/VoteProgress.tsx
@@ -34,9 +34,11 @@ const VoteProgress = ({ ayeVotes, className, nayVotes, passingThreshold }: Props
 	const isPassing = passingThreshold.lt(ayeVotes);
 	const ayeVotesNumber = bnToIntBalance(ayeVotes);
 	const totalVotesNumber = bnToIntBalance(ayeVotes.add(nayVotes));
+	const passingDivider = totalVotesNumber || 1;
+	const nonPassingDivider = passingThresholdNumber+nayVotesNumber || 1;
 	const passingThresholdPercent = isPassing
-		? passingThresholdNumber/totalVotesNumber*100
-		: passingThresholdNumber/(passingThresholdNumber+nayVotesNumber)*100;
+		? passingThresholdNumber/passingDivider*100
+		: passingThresholdNumber/nonPassingDivider*100;
 	const ayePercent = ayeVotesNumber/totalVotesNumber*100;
 
 	return (


### PR DESCRIPTION
closes #733 by preventing a division by 0.

![image](https://user-images.githubusercontent.com/33178835/80730696-2ed70a00-8b0a-11ea-860a-699a5ef9f6cc.png)
