### PR TITLE
Wider comment thread

### DIFF
--- a/front-end/src/components/Post/GovernanceSideBar/Proposals/ProposalVoteInfo.tsx
+++ b/front-end/src/components/Post/GovernanceSideBar/Proposals/ProposalVoteInfo.tsx
@@ -60,25 +60,22 @@ const ProposalVoteInfo = ({ className, proposalId }:  Props) => {
 				?
 				<Loader text={loadingStatus.message} timeout={3000} timeoutText={'Api is unresponsive'}/>
 				:
-				<>
-					<h3>Overview</h3>
-					<Grid columns={3} divided>
-						<Grid.Row>
-							<Grid.Column>
-								<h6>Deposit</h6>
-								<div>{deposit}</div>
-							</Grid.Column>
-							<Grid.Column>
-								<h6>Seconded by</h6>
-								{seconds ? <div>{seconds} addresses</div> : null}
-							</Grid.Column>
-							<Grid.Column>
-								<h6>Locked {chainProperties[currentNetwork].tokenSymbol}</h6>
-								<div>{seconds * parseInt(deposit.split(' ')[0]) || 0}</div>
-							</Grid.Column>
-						</Grid.Row>
-					</Grid>
-				</>
+				<Grid columns={3} divided>
+					<Grid.Row>
+						<Grid.Column>
+							<h6>Deposit</h6>
+							<div>{deposit}</div>
+						</Grid.Column>
+						<Grid.Column>
+							<h6>Seconded by</h6>
+							{seconds ? <div>{seconds} addresses</div> : null}
+						</Grid.Column>
+						<Grid.Column>
+							<h6>Locked {chainProperties[currentNetwork].tokenSymbol}</h6>
+							<div>{seconds * parseInt(deposit.split(' ')[0]) || 0}</div>
+						</Grid.Column>
+					</Grid.Row>
+				</Grid>
 			}
 		</Card>
 	);

--- a/front-end/src/components/Post/GovernanceSideBar/Referenda/ReferendumVoteInfo.tsx
+++ b/front-end/src/components/Post/GovernanceSideBar/Referenda/ReferendumVoteInfo.tsx
@@ -101,7 +101,6 @@ const ReferendumVoteInfo = ({ className, referendumId, threshold }: Props) => {
 				<Loader text={loadingStatus.message} timeout={3000} timeoutText='Api is unresponsive.'/>
 				:
 				<>
-					<h3>Overview</h3>
 					<VoteProgress
 						ayeVotes={ayeVotes}
 						className='vote-progress'

--- a/front-end/src/components/Post/Post.tsx
+++ b/front-end/src/components/Post/Post.tsx
@@ -126,7 +126,7 @@ const Post = ( { className, data, isMotion = false, isProposal = false, isRefere
 
 	return (
 		<Grid className={className}>
-			<Grid.Column mobile={16} tablet={16} computer={10}>
+			<Grid.Column mobile={16} tablet={16} computer={11}>
 				<div className='post_content'>
 					<EditablePostContent
 						isEditing={isEditing}
@@ -172,7 +172,7 @@ const Post = ( { className, data, isMotion = false, isProposal = false, isRefere
 				}
 				{ id && <CreatePostComment postId={post.id} refetch={refetch} /> }
 			</Grid.Column>
-			<Grid.Column className='democracy_card' mobile={16} tablet={16} computer={6}>
+			<Grid.Column className='democracy_card' mobile={16} tablet={16} computer={5}>
 				<GovenanceSideBar
 					isMotion={isMotion}
 					isProposal={isProposal}

--- a/front-end/src/themes/theme.ts
+++ b/front-end/src/themes/theme.ts
@@ -41,7 +41,8 @@ export const theme = {
 		font_secondary: 'Work Sans'
 	},
 	radii: {
-		button_radius: '0.3rem'
+		button_radius: '0.3rem',
+		input_border_radius: '0.3rem'
 	},
 	shadows: {
 		box_shadow_secondary_grey: '0 0 0 1px #706D6D inset',

--- a/front-end/src/themes/theme.ts
+++ b/front-end/src/themes/theme.ts
@@ -28,7 +28,7 @@ export const theme = {
 		white_transparent: 'rgba(255, 255, 255, 0.2)'
 	},
 	fontSizes: {
-		input_text_size: '1.3rem',
+		input_text_size: '1.4rem',
 		lg: '1.8rem',
 		md: '1.5rem',
 		sm: '1.3rem',

--- a/front-end/src/ui-components/AddressDropdown.tsx
+++ b/front-end/src/ui-components/AddressDropdown.tsx
@@ -65,10 +65,7 @@ const AddressDropdown = ({ accounts, className, defaultAddress, filterAccounts, 
 
 export default styled(AddressDropdown)`
 	width: 100%;
-	border-color: grey_light;
-	border-style: solid;
-	border-width: 1px;
-	padding: 1rem .4rem .4rem 1.2rem;
+	padding: 1.4rem .4rem .8rem 1.2rem;
 
 	.address-wrapper {
 		display: inline-block;

--- a/front-end/src/ui-components/Form.tsx
+++ b/front-end/src/ui-components/Form.tsx
@@ -26,7 +26,6 @@ export function Form({ className, standalone=true, ...props } : FormProps): Reac
 const StyledForm = styled(SUIForm)`
 	&.standalone {
 		background-color: white;
-		margin-top: 2rem;
 		padding: 2rem 3rem 3rem 3rem;
 		border-style: solid;
 		border-width: 1px;
@@ -87,7 +86,7 @@ const StyledForm = styled(SUIForm)`
 		input[type=file], input[type=number], input[type=password], input[type=search], input[type=tel], 
 		input[type=text], input[type=time], input[type=url] {
 			font-family: font_default;
-			font-size: 1.3rem;
+			font-size: input_text_size;
 			color: black_primary;
 			border-style: solid;
 			border-width: 1px;
@@ -98,7 +97,7 @@ const StyledForm = styled(SUIForm)`
 			margin-bottom: 1.2rem;
 			&:focus {
 				font-family: font_default;
-				font-size: 1.3rem;
+				font-size: input_text_size;
 				color: black_text;
 				border-color: grey_primary;
 				border-radius: 0rem;
@@ -135,6 +134,9 @@ const StyledForm = styled(SUIForm)`
 	.ui.selection.dropdown {
 		font-size: input_text_size;
 		margin-bottom: 1.2rem;
+		border-style: solid;
+		border-width: 1px;
+		border-color: grey_light;
 		border-radius: 0rem;
 
 		.menu .active.item {

--- a/front-end/src/ui-components/Form.tsx
+++ b/front-end/src/ui-components/Form.tsx
@@ -132,7 +132,7 @@ const StyledForm = styled(SUIForm)`
 
 	.ui.dropdown,
 	.ui.selection.dropdown {
-		font-size: input_text_size;
+		font-size: sm;
 		margin-bottom: 1.2rem;
 		border-style: solid;
 		border-width: 1px;

--- a/front-end/src/ui-components/Form.tsx
+++ b/front-end/src/ui-components/Form.tsx
@@ -91,7 +91,7 @@ const StyledForm = styled(SUIForm)`
 			border-style: solid;
 			border-width: 1px;
 			border-color: grey_light;
-			border-radius: 0.3rem;
+			border-radius: input_border_radius;
 			text-indent: 0rem;
 			padding: 1rem;
 			margin-bottom: 1.2rem;
@@ -100,7 +100,7 @@ const StyledForm = styled(SUIForm)`
 				font-size: input_text_size;
 				color: black_text;
 				border-color: grey_primary;
-				border-radius: 0rem;
+				border-radius: input_border_radius;
 			}
 			&:hover {
 				border-color: grey_secondary;
@@ -137,7 +137,11 @@ const StyledForm = styled(SUIForm)`
 		border-style: solid;
 		border-width: 1px;
 		border-color: grey_light;
-		border-radius: 0.3rem;
+		border-radius: input_border_radius;
+
+		.menu {
+			border-color: grey_light;
+		}
 
 		.menu .active.item {
 			font-weight: 500;
@@ -149,6 +153,10 @@ const StyledForm = styled(SUIForm)`
 
 		.menu>.item:hover {
 			background-color: grey_light;
+		}
+
+		.visible.menu.transition {
+			border-radius: input_border_radius;
 		}
 	}
 

--- a/front-end/src/ui-components/Form.tsx
+++ b/front-end/src/ui-components/Form.tsx
@@ -91,7 +91,7 @@ const StyledForm = styled(SUIForm)`
 			border-style: solid;
 			border-width: 1px;
 			border-color: grey_light;
-			border-radius: 0rem;
+			border-radius: 0.3rem;
 			text-indent: 0rem;
 			padding: 1rem;
 			margin-bottom: 1.2rem;
@@ -137,7 +137,7 @@ const StyledForm = styled(SUIForm)`
 		border-style: solid;
 		border-width: 1px;
 		border-color: grey_light;
-		border-radius: 0rem;
+		border-radius: 0.3rem;
 
 		.menu .active.item {
 			font-weight: 500;

--- a/front-end/src/ui-components/Input.tsx
+++ b/front-end/src/ui-components/Input.tsx
@@ -20,7 +20,7 @@ export default styled(Input)`
         font-size: input_text_size;
         border-width: 1px;
         border-color: grey_light;
-        border-radius: 0rem;
+        border-radius: 0.3rem;
         text-indent: 0rem;
         padding: 1rem;
         margin-bottom: 1.2rem;
@@ -29,7 +29,7 @@ export default styled(Input)`
             font-size: input_text_size;
             color: black_text;
             border-color: grey_primary;
-            border-radius: 0rem;
+            border-radius: 0.3rem;
         }
         &:hover {
             border-color: grey_secondary;

--- a/front-end/src/ui-components/Input.tsx
+++ b/front-end/src/ui-components/Input.tsx
@@ -26,7 +26,7 @@ export default styled(Input)`
         margin-bottom: 1.2rem;
         &:focus {
             font-family: font_default;
-            font-size: 1.3rem;
+            font-size: input_text_size;
             color: black_text;
             border-color: grey_primary;
             border-radius: 0rem;

--- a/front-end/src/ui-components/Input.tsx
+++ b/front-end/src/ui-components/Input.tsx
@@ -20,7 +20,7 @@ export default styled(Input)`
         font-size: input_text_size;
         border-width: 1px;
         border-color: grey_light;
-        border-radius: 0.3rem;
+        border-radius: input_border_radius;
         text-indent: 0rem;
         padding: 1rem;
         margin-bottom: 1.2rem;
@@ -29,7 +29,7 @@ export default styled(Input)`
             font-size: input_text_size;
             color: black_text;
             border-color: grey_primary;
-            border-radius: 0.3rem;
+            border-radius: input_border_radius;
         }
         &:hover {
             border-color: grey_secondary;


### PR DESCRIPTION
First steps towards #710 

Made the post & comment column a bit wider, gov sidebar a bit narrower. Increased input sizes a tiny bit and made them coherent. Removed the unnecessary "Overview" heading from the gov sidebar.

Before
<img width="1389" alt="Screenshot 2020-05-04 at 10 37 32" src="https://user-images.githubusercontent.com/7072141/80949080-98e5fc80-8df3-11ea-8650-a2d833fdc891.png">

After
<img width="1387" alt="Screenshot 2020-05-04 at 10 37 40" src="https://user-images.githubusercontent.com/7072141/80949089-9c798380-8df3-11ea-829d-38af62cdc16b.png">

Before
<img width="1394" alt="Screenshot 2020-05-04 at 10 37 50" src="https://user-images.githubusercontent.com/7072141/80949122-aef3bd00-8df3-11ea-85d6-94f1e7e58d11.png">

After
<img width="1385" alt="Screenshot 2020-05-04 at 10 37 58" src="https://user-images.githubusercontent.com/7072141/80949130-b3b87100-8df3-11ea-889d-79add17b9f30.png">

