### PR TITLE
Set timeout 3s -> 30s

### DIFF
--- a/front-end/src/components/Post/GovernanceSideBar/Proposals/ProposalVoteInfo.tsx
+++ b/front-end/src/components/Post/GovernanceSideBar/Proposals/ProposalVoteInfo.tsx
@@ -58,7 +58,7 @@ const ProposalVoteInfo = ({ className, proposalId }:  Props) => {
 		<Card className={loadingStatus.isLoading ? `LoaderWrapper ${className}` : className}>
 			{loadingStatus.isLoading
 				?
-				<Loader text={loadingStatus.message} timeout={3000} timeoutText={'Api is unresponsive'}/>
+				<Loader text={loadingStatus.message} timeout={30000} timeoutText={'Api is unresponsive'}/>
 				:
 				<>
 					<h3>Overview</h3>

--- a/front-end/src/components/Post/GovernanceSideBar/Referenda/ReferendumVoteInfo.tsx
+++ b/front-end/src/components/Post/GovernanceSideBar/Referenda/ReferendumVoteInfo.tsx
@@ -98,7 +98,7 @@ const ReferendumVoteInfo = ({ className, referendumId, threshold }: Props) => {
 		<Card className={loadingStatus.isLoading ? `LoaderWrapper ${className}` : className}>
 			{loadingStatus.isLoading
 				?
-				<Loader text={loadingStatus.message} timeout={3000} timeoutText='Api is unresponsive.'/>
+				<Loader text={loadingStatus.message} timeout={30000} timeoutText='Api is unresponsive.'/>
 				:
 				<>
 					<h3>Overview</h3>


### PR DESCRIPTION
A timeout of 3s always show this "Api unresponsive" message. Since it's a timeout, it should appear when things are really wrong, not when it's just slow, it generally takes 4s on a newly loaded page. 

Didn't check in details when reviewing, I thought it was 30s.