### PR TITLE
Add scrollbar to account dropdown

### DIFF
--- a/front-end/src/ui-components/AddressDropdown.tsx
+++ b/front-end/src/ui-components/AddressDropdown.tsx
@@ -74,6 +74,8 @@ export default styled(AddressDropdown)`
 	.visible.menu.transition {
 		width: 100%;
 		border-radius: 0;
+		max-height: 20rem;
+		overflow: auto;
 	}
 
 	.dropdown.icon {


### PR DESCRIPTION
Looks like this on Firefox
![image](https://user-images.githubusercontent.com/33178835/81170384-e18bea00-8f9a-11ea-964f-bdcd77f6f5ad.png)

without this, smaller screens where looking bad, making the footer to not stick etc..
![image](https://user-images.githubusercontent.com/33178835/81170805-97573880-8f9b-11ea-80f2-242d0295b7f2.png)

