### PR TITLE
Fix to show the parent display name first

### DIFF
--- a/front-end/src/ui-components/Address.tsx
+++ b/front-end/src/ui-components/Address.tsx
@@ -32,7 +32,7 @@ const Address = ({ address, className, displayInline, extensionName, popupConten
 		let unsubscribe: () => void;
 
 		api.derive.accounts.info(address, (info: DeriveAccountInfo) =>
-			setDisplay(info.identity.display || info.nickname || ''))
+			setDisplay(info.identity.displayParent || info.identity.display || info.nickname || ''))
 			.then(unsub => { unsubscribe = unsub; })
 			.catch(e => console.error(e));
 

--- a/front-end/src/ui-components/Address.tsx
+++ b/front-end/src/ui-components/Address.tsx
@@ -34,9 +34,13 @@ const Address = ({ address, className, displayInline, extensionName, popupConten
 
 		api.derive.accounts.info(address, (info: DeriveAccountInfo) => {
 			if (info.identity.displayParent && info.identity.display){
+				// when an identity is a sub identity `displayParent` is set
+				// and `display` get the sub identity
 				setMainDisplay(info.identity.displayParent);
 				setSub(info.identity.display);
 			} else {
+				// There should not be a `displayParent` without a `display`
+				// but we can't be too sure.
 				setMainDisplay(info.identity.displayParent || info.identity.display || info.nickname || '');
 			}
 		})

--- a/front-end/src/ui-components/Address.tsx
+++ b/front-end/src/ui-components/Address.tsx
@@ -64,7 +64,8 @@ const Address = ({ address, className, displayInline, extensionName, popupConten
 					? popupContent
 						? <Popup
 							trigger={
-								<div className={'header inline'}>{mainDisplay || shortenAddress(address)}
+								<div className={'header inline'}>
+									{mainDisplay || shortenAddress(address)}
 									{sub && <span className='sub'>/{sub}</span>}
 								</div>
 							}

--- a/front-end/src/ui-components/Address.tsx
+++ b/front-end/src/ui-components/Address.tsx
@@ -21,7 +21,8 @@ interface Props {
 
 const Address = ({ address, className, displayInline, extensionName, popupContent }: Props): JSX.Element => {
 	const { api, isApiReady } = useContext(ApiPromiseContext);
-	const [display, setDisplay] = useState<string>('');
+	const [mainDisplay, setMainDisplay] = useState<string>('');
+	const [sub, setSub] = useState<string | null>(null);
 
 	useEffect(() => {
 
@@ -31,8 +32,14 @@ const Address = ({ address, className, displayInline, extensionName, popupConten
 
 		let unsubscribe: () => void;
 
-		api.derive.accounts.info(address, (info: DeriveAccountInfo) =>
-			setDisplay(info.identity.displayParent || info.identity.display || info.nickname || ''))
+		api.derive.accounts.info(address, (info: DeriveAccountInfo) => {
+			if (info.identity.displayParent && info.identity.display){
+				setMainDisplay(info.identity.displayParent);
+				setSub(info.identity.display);
+			} else {
+				setMainDisplay(info.identity.displayParent || info.identity.display || info.nickname || '');
+			}
+		})
 			.then(unsub => { unsubscribe = unsub; })
 			.catch(e => console.error(e));
 
@@ -52,20 +59,30 @@ const Address = ({ address, className, displayInline, extensionName, popupConten
 					// When inline disregard the extension name.
 					? popupContent
 						? <Popup
-							trigger={<div className={'header inline'}>{display || shortenAddress(address)}</div>}
+							trigger={
+								<div className={'header inline'}>{mainDisplay || shortenAddress(address)}
+									{sub && <span className='sub'>/{sub}</span>}
+								</div>
+							}
 							content={popupContent}
 							hoverable={true}
 							position='top center'
 						/>
 						: <>
-							<div className={'description inline'}>{ display || shortenAddress(address)}</div>
+							<div className={'description inline'}>
+								{ mainDisplay || shortenAddress(address)}
+								{sub && <span className='sub'>/{sub}</span>}
+							</div>
 						</>
-					: extensionName || display
+					: extensionName || mainDisplay
 						? popupContent
 							? <Popup
 								trigger={
 									<>
-										<div className={'header'}>{extensionName || display}</div>
+										<div className={'header'}>
+											{extensionName || mainDisplay}
+											{sub && <span className='sub'>/{sub}</span>}
+										</div>
 										<div className={'description inline'}>{shortenAddress(address)}</div>
 									</>
 								}
@@ -74,7 +91,10 @@ const Address = ({ address, className, displayInline, extensionName, popupConten
 								position='top center'
 							/>
 							: <>
-								<div className={'header'}>{extensionName || display}</div>
+								<div className={'header'}>
+									{extensionName || mainDisplay}
+									{sub && <span className='sub'>/{sub}</span>}
+								</div>
 								<div className={'description'}>{shortenAddress(address)}</div>
 							</>
 						: <div className={'description'}>{shortenAddress(address)}</div>
@@ -119,5 +139,9 @@ export default styled(Address)`
 	}
 	&.inline .content {
 		line-height: inherit !important;
+	}
+
+	.sub {
+		color: grey_secondary;
 	}
 `;


### PR DESCRIPTION
which puts the proposer of https://kusama.polkassembly.io/proposal/20 to Logan
![image](https://user-images.githubusercontent.com/33178835/81352186-36784f00-90c6-11ea-97af-ae17f8808ebd.png)

![image](https://user-images.githubusercontent.com/33178835/81352249-6293d000-90c6-11ea-8ae7-cefe26145fb2.png)


More info on the sub here: https://wiki.polkadot.network/docs/en/learn-identity#sub-accounts
