### PR TITLE
Voting Progress Bar overflow fix on small desktop width

### DIFF
--- a/front-end/src/components/Post/Post.tsx
+++ b/front-end/src/components/Post/Post.tsx
@@ -126,7 +126,7 @@ const Post = ( { className, data, isMotion = false, isProposal = false, isRefere
 
 	return (
 		<Grid className={className}>
-			<Grid.Column mobile={16} tablet={16} computer={11}>
+			<Grid.Column mobile={16} tablet={16} computer={10} largeScreen={11}>
 				<div className='post_content'>
 					<EditablePostContent
 						isEditing={isEditing}
@@ -172,7 +172,7 @@ const Post = ( { className, data, isMotion = false, isProposal = false, isRefere
 				}
 				{ id && <CreatePostComment postId={post.id} refetch={refetch} /> }
 			</Grid.Column>
-			<Grid.Column className='democracy_card' mobile={16} tablet={16} computer={5}>
+			<Grid.Column className='democracy_card' mobile={16} tablet={16} computer={6} largeScreen={5}>
 				<GovenanceSideBar
 					isMotion={isMotion}
 					isProposal={isProposal}

--- a/front-end/src/ui-components/GlobalStyle.tsx
+++ b/front-end/src/ui-components/GlobalStyle.tsx
@@ -61,6 +61,10 @@ export const GlobalStyle = createGlobalStyle`
     .ui.container {
         margin: 4rem auto 0 auto;
         padding-bottom: 8rem;
+
+        @media only screen and (max-width: 1199px) and (min-width: 992px) {
+            width: calc(100% - 4rem);
+        }
     }
 
     h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
Closes #771.

It's a bit of a compromise as we don't want to have a narrow comment thread again. For the small desktop breakpoint range (992px -1199p) the app container goes full width with a 20px margin.

995px window width with larger vote turnout:
<img width="991" alt="Screenshot 2020-05-09 at 18 59 46" src="https://user-images.githubusercontent.com/7072141/81480078-92a6b480-9227-11ea-94a7-6e61ccb5b7ec.png">
