### PR TITLE
fix ui glitches

### DIFF
--- a/front-end/src/components/Comment/Comment.tsx
+++ b/front-end/src/components/Comment/Comment.tsx
@@ -63,12 +63,12 @@ export const Comment = ({ className, comment, refetch } : Props) => {
 					defaultAddress={defaultAddress}
 					text={'commented'}
 					username={author.username}
-				/>
-				<UpdateLabel
-					className='update-label'
-					created_at={created_at}
-					updated_at={updated_at}
-				/>
+				>
+					<UpdateLabel
+						created_at={created_at}
+						updated_at={updated_at}
+					/>
+				</CreationLabel>
 				<EditableCommentContent
 					authorId={author.id}
 					className='comment-content'
@@ -111,13 +111,9 @@ export default styled(Comment)`
 	}
 
 	.creation-label {
-		display: inline-block;
+		display: inline-flex;
 		padding: 1rem 0 0.8rem 2rem;
 		margin-bottom: 0;
-	}
-
-	.update-label {
-		display: inline-block;
 	}
 
 	.comment-content {

--- a/front-end/src/components/Post/PostContent.tsx
+++ b/front-end/src/components/Post/PostContent.tsx
@@ -41,12 +41,13 @@ const PostContent = ({ className, onchainId, post, postStatus }:Props) => {
 							defaultAddress={defaultAddress}
 							username={author.username}
 							topic={post.topic.name}
-						/>
-						<UpdateLabel
-							className='md'
-							created_at={created_at}
-							updated_at={updated_at}
-						/>
+						>
+							<UpdateLabel
+								className='md'
+								created_at={created_at}
+								updated_at={updated_at}
+							/>
+						</CreationLabel>
 					</>
 				}
 			</div>

--- a/front-end/src/ui-components/Address.tsx
+++ b/front-end/src/ui-components/Address.tsx
@@ -123,18 +123,20 @@ export default styled(Address)`
 		margin-right: 0.8rem;
 	}
 
+	.header, .description{
+		filter: grayscale(100%);
+		margin-right: 0.4rem;
+	}
+
 	.header {
 		color: black_text;
 		font-weight: 500;
 		font-size: sm;
-		filter: grayscale(100%);
-		margin-right: 0.4rem;
 	}
 
 	.description {
 		color: grey_primary;
 		font-size: xs;
-		margin-right: 0.4rem;
 	}
 
 	.inline {

--- a/front-end/src/ui-components/Address.tsx
+++ b/front-end/src/ui-components/Address.tsx
@@ -116,7 +116,6 @@ export default styled(Address)`
 
 	.content {
 		display: inline-block;
-		line-height: 1.6rem;
 	}
 
 	.identicon {
@@ -144,11 +143,9 @@ export default styled(Address)`
 		font-size: sm !important;
 	
 	}
-	&.inline .content {
-		line-height: inherit !important;
-	}
 
 	.sub {
 		color: grey_secondary;
+		line-height: inherit;
 	}
 `;

--- a/front-end/src/ui-components/CreationLabel.tsx
+++ b/front-end/src/ui-components/CreationLabel.tsx
@@ -4,13 +4,14 @@
 
 import styled from '@xstyled/styled-components';
 import * as moment from 'moment';
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import InlineTag from './InlineTag';
 import NameLabel from './NameLabel';
 
 interface Props{
 	className?: string
+	children?: ReactNode
 	created_at?: Date
 	defaultAddress?: string | null
 	text?: string
@@ -18,7 +19,7 @@ interface Props{
 	username?: string
 }
 
-const CreationLabel = ({ className, created_at, defaultAddress, text='posted', username, topic } : Props) => {
+const CreationLabel = ({ className, children, created_at, defaultAddress, text='posted', username, topic } : Props) => {
 	return <div className={className}>
 		<NameLabel
 			defaultAddress={defaultAddress}
@@ -31,6 +32,7 @@ const CreationLabel = ({ className, created_at, defaultAddress, text='posted', u
 		{created_at &&
 			moment.utc(created_at, 'YYYY-MM-DDTHH:mm:ss.SSS').fromNow()
 		}
+		{children}
 	</div>;
 };
 
@@ -38,12 +40,6 @@ export default styled(CreationLabel)`
 	color: grey_primary;
 	font-weight: 400;
 	font-size: sm;
-	margin-bottom: 0.6rem;
 	display: inline-flex;
-		
-	span {
-		color: black_text;
-		font-weight: 500;
-		margin-right: 0.3rem;
-	}
+	align-items: center;
 `;

--- a/front-end/src/ui-components/NameLabel.tsx
+++ b/front-end/src/ui-components/NameLabel.tsx
@@ -30,12 +30,13 @@ export default styled(NameLabel)`
 	color: grey_primary;
 	font-weight: 400;
 	font-size: sm;
-	margin-bottom: 0.6rem;
+	/* margin-bottom: 0.6rem; */
 	display: inline-flex;
 		
 	span {
 		color: black_text;
 		font-weight: 500;
 		margin-right: 0.3rem;
+		line-height: 1.3rem;
 	}
 `;

--- a/front-end/src/ui-components/NameLabel.tsx
+++ b/front-end/src/ui-components/NameLabel.tsx
@@ -30,7 +30,6 @@ export default styled(NameLabel)`
 	color: grey_primary;
 	font-weight: 400;
 	font-size: sm;
-	/* margin-bottom: 0.6rem; */
 	display: inline-flex;
 		
 	span {

--- a/front-end/src/ui-components/UpdateLabel.tsx
+++ b/front-end/src/ui-components/UpdateLabel.tsx
@@ -26,8 +26,5 @@ const UpdateLabel = ({ className, created_at, updated_at } : Props) => {
 export default styled(UpdateLabel)`
     margin-left: .5rem;
     font-size: sm;
-    
-    span {
-        color: grey_secondary;
-    }
-}`;
+    color: grey_secondary;
+`;


### PR DESCRIPTION
closes #766 

proposer and comments look better (with or without identity, `(edited)` stays in place as well):
![image](https://user-images.githubusercontent.com/33178835/81568726-7bd69e00-939e-11ea-8186-649cb14161a8.png)

proposal are greyed out again
![image](https://user-images.githubusercontent.com/33178835/81568764-85600600-939e-11ea-9726-c102399a4ec6.png)

posts are still all right with topic fixed
![image](https://user-images.githubusercontent.com/33178835/81568805-9446b880-939e-11ea-9a79-d0d0631b87d9.png)

