### PR TITLE
Sidebar glitch fix

### DIFF
--- a/front-end/src/components/Post/GovernanceSideBar/Referenda/ReferendumVoteInfo.tsx
+++ b/front-end/src/components/Post/GovernanceSideBar/Referenda/ReferendumVoteInfo.tsx
@@ -95,19 +95,15 @@ const ReferendumVoteInfo = ({ className, referendumId, threshold }: Props) => {
 						passingThreshold={passingThreshold}
 						nayVotes={nayVotes}
 					/>
-					<Grid columns={3} divided>
+					<Grid columns={2} divided>
 						<Grid.Row>
 							<Grid.Column>
 								<h6>Turnout</h6>
 								<div>{formatBnBalance(turnout, { numberAfterComma: 2 })}</div>
 							</Grid.Column>
-							<Grid.Column width={5}>
-								<h6>Aye</h6>
-								<div>{formatBnBalance(ayeVotes, { numberAfterComma: 2 })}</div>
-							</Grid.Column>
-							<Grid.Column width={5}>
-								<h6>Nay</h6>
-								<div>{formatBnBalance(nayVotes, { numberAfterComma: 2 })}</div>
+							<Grid.Column>
+								<h6>Electorate</h6>
+								<div>{formatBnBalance(electorate, { numberAfterComma: 2 })}</div>
 							</Grid.Column>
 						</Grid.Row>
 					</Grid>

--- a/front-end/src/components/Post/Post.tsx
+++ b/front-end/src/components/Post/Post.tsx
@@ -126,7 +126,7 @@ const Post = ( { className, data, isMotion = false, isProposal = false, isRefere
 
 	return (
 		<Grid className={className}>
-			<Grid.Column mobile={16} tablet={16} computer={10} largeScreen={11}>
+			<Grid.Column mobile={16} tablet={16} computer={10} largeScreen={10}>
 				<div className='post_content'>
 					<EditablePostContent
 						isEditing={isEditing}
@@ -172,7 +172,7 @@ const Post = ( { className, data, isMotion = false, isProposal = false, isRefere
 				}
 				{ id && <CreatePostComment postId={post.id} refetch={refetch} /> }
 			</Grid.Column>
-			<Grid.Column className='democracy_card' mobile={16} tablet={16} computer={6} largeScreen={5}>
+			<Grid.Column className='democracy_card' mobile={16} tablet={16} computer={6} largeScreen={6}>
 				<GovenanceSideBar
 					isMotion={isMotion}
 					isProposal={isProposal}
@@ -227,7 +227,7 @@ export default styled(Post)`
 		}
 	}
 
-	@media only screen and (max-width: 992px) {
+	@media only screen and (max-width: 991px) {
 		.democracy_card {
 			visibility: hidden;
 		}

--- a/front-end/src/ui-components/GlobalStyle.tsx
+++ b/front-end/src/ui-components/GlobalStyle.tsx
@@ -51,6 +51,11 @@ export const GlobalStyle = createGlobalStyle`
         max-width: 1200px;
         padding: 0 2.5rem 0 2.5rem;
         margin: 3.75rem auto 0 auto;
+
+		@media (max-width: 1299px) {
+			padding: 0 2.5rem 0 2.5rem;
+		}
+    }
     }
 
     #page-container {
@@ -62,8 +67,12 @@ export const GlobalStyle = createGlobalStyle`
         margin: 4rem auto 0 auto;
         padding-bottom: 8rem;
 
-        @media only screen and (max-width: 1199px) and (min-width: 992px) {
-            width: calc(100% - 4rem);
+        @media only screen and (max-width: 1299px) and (min-width: 992px) {
+            width: calc(100% - 6rem);
+        }
+
+        @media only screen and (min-width: 1299px) {
+            width: 1238px;
         }
     }
 
@@ -116,17 +125,6 @@ export const GlobalStyle = createGlobalStyle`
 
     .ui.dropdown .menu, .ui.dropdown .menu>.item {
         font-size: sm;
-    }
-
-    @media (max-width: 1200px) {
-        .container-fluid {
-        padding: 0 2.5rem 0 2.5rem;
-        }
-
-        .ui.grid {
-            margin-left: 0;
-            margin-right: 0;
-        }
     }
 
     @media only screen and (max-width: 768px) {


### PR DESCRIPTION
Closes #788

Tested with larger numbers on big screens
<img width="1178" alt="Screenshot 2020-05-18 at 15 32 34" src="https://user-images.githubusercontent.com/7072141/82226118-62959a80-9926-11ea-8512-cbd01124f5e0.png">

They will line-break with ~1145px screen width or less. Current six-figure numbers don't though.
<img width="414" alt="Screenshot 2020-05-18 at 16 39 16" src="https://user-images.githubusercontent.com/7072141/82226122-64f7f480-9926-11ea-840e-809365da3c1f.png">

Also fixed a glitch around ~993px where the sidebar would be set to `hidden`