### PR TITLE
Disable unlinking default address

### DIFF
--- a/front-end/src/screens/Settings/address.tsx
+++ b/front-end/src/screens/Settings/address.tsx
@@ -196,6 +196,7 @@ const Address = ({ className }: Props): JSX.Element => {
 											<div className='button-container'>
 												<Button
 													className={'social'}
+													disabled={currentUser.defaultAddress === address}
 													negative={showOnlyUnlink ? true : currentUser.addresses?.includes(address) ? true : false}
 													onClick={() => showOnlyUnlink ? handleUnlink(address) : currentUser.addresses?.includes(address) ? handleUnlink(address) : handleLink(address, account)}
 												>

--- a/front-end/src/screens/Settings/address.tsx
+++ b/front-end/src/screens/Settings/address.tsx
@@ -6,8 +6,9 @@ import { web3Accounts, web3Enable,web3FromSource } from '@polkadot/extension-dap
 import { InjectedAccountWithMeta } from '@polkadot/extension-inject/types';
 import { stringToHex } from '@polkadot/util';
 import styled from '@xstyled/styled-components';
-import React, { useContext,useState } from 'react';
-import { Grid,Icon } from 'semantic-ui-react';
+import React, { useContext, useState } from 'react';
+import { Grid, Icon } from 'semantic-ui-react';
+import HelperTooltip from 'src/ui-components/HelperTooltip';
 
 import ExtensionNotDetected from '../../components/ExtensionNotDetected';
 import { NotificationContext } from '../../context/NotificationContext';
@@ -202,6 +203,11 @@ const Address = ({ className }: Props): JSX.Element => {
 												>
 													{showOnlyUnlink ? unlinkIcon : currentUser.addresses?.includes(address) ? unlinkIcon : linkIcon}
 												</Button>
+												{currentUser.defaultAddress === address &&
+													<HelperTooltip
+														content='You can&apos;t unlink your default address.'
+													/>
+												}
 											</div>
 										</Grid.Column>
 										<Grid.Column width={6} >


### PR DESCRIPTION
Closes #754
<img width="341" alt="Screenshot 2020-05-25 at 16 07 10" src="https://user-images.githubusercontent.com/7072141/82820204-0bea0c80-9ea2-11ea-8026-fdfef7d6606d.png">

I initially tried to had the button itself as the popup trigger, but had trouble with refs, so went with the `HelperTooltip` next to it