### PR TITLE
fix rpc-node internal hostname

### DIFF
--- a/kubernetes/polkassembly/values-parity-prod.yaml
+++ b/kubernetes/polkassembly/values-parity-prod.yaml
@@ -43,4 +43,4 @@ healthMonitor:
     # polkassembly frontend-service
     REACT_SERVER: "http://frontend-service:80"
     # polkadot rpc node
-    ARCHIVE_NODE_ENDPOINT: "ws://polkassembly-rpc-internal-0.parity-prod.parity.io:9944"
+    ARCHIVE_NODE_ENDPOINT: "ws://polkassembly-rpc-internal-0.c.parity-prod.internal:9944"


### PR DESCRIPTION
hostname to access rpc-archive node differ depending on requesting  it's internal (10.11.0.44) or external (35.246.212.218) ip-address. if requesting from within *parity-prod* cluster better to use the internal address for reasons of managing firewall rules.