### PR TITLE
Fix threshold position if outside of screen

### DIFF
--- a/front-end/src/ui-components/VoteProgress.tsx
+++ b/front-end/src/ui-components/VoteProgress.tsx
@@ -51,7 +51,7 @@ const VoteProgress = ({ ayeVotes, className, isPassing, nayVotes, threshold }: P
 				// don't show the threshold if it's not been calculated yet
 				thresholdPercent > 0 &&  <div
 					id='passingThreshold'
-					style={{ left: thresholdPercent + '%' }}
+					style={{ left: (thresholdPercent > 100 ? 100 : thresholdPercent) + '%' }}
 				>
 					<hr/>
 					<div


### PR DESCRIPTION
Closes #820 by limiting the threshold position to 100% if above 100.
<img width="489" alt="Screenshot 2020-05-30 at 15 12 21" src="https://user-images.githubusercontent.com/7072141/83329170-411ea200-a288-11ea-9113-8720b7768145.png">
