### PR TITLE
Fix threshold outside of screen

### DIFF
--- a/front-end/src/ui-components/VoteProgress.tsx
+++ b/front-end/src/ui-components/VoteProgress.tsx
@@ -30,8 +30,8 @@ const VoteProgress = ({ ayeVotes, className, isPassing, nayVotes, threshold }: P
 	const ayeVotesNumber = bnToIntBalance(ayeVotes);
 	const totalVotesNumber = bnToIntBalance(ayeVotes.add(nayVotes));
 	const totalVotesNumberDivider = isPassing 
-	? bnToIntBalance(nayVotes.add(threshold)) || 1
-	: bnToIntBalance(ayeVotes.add(threshold)) || 1;
+	? bnToIntBalance(ayeVotes.add(threshold))
+	: bnToIntBalance(nayVotes.add(threshold)) || 1;
 	const thresholdPercent = isPassing
 		? (1-thresholdNumber/totalVotesNumberDivider)*100
 		: thresholdNumber / totalVotesNumberDivider*100;

--- a/front-end/src/ui-components/VoteProgress.tsx
+++ b/front-end/src/ui-components/VoteProgress.tsx
@@ -29,7 +29,9 @@ const VoteProgress = ({ ayeVotes, className, isPassing, nayVotes, threshold }: P
 	const thresholdNumber = bnToIntBalance(threshold);
 	const ayeVotesNumber = bnToIntBalance(ayeVotes);
 	const totalVotesNumber = bnToIntBalance(ayeVotes.add(nayVotes));
-	const totalVotesNumberDivider = totalVotesNumber || 1;
+	const totalVotesNumberDivider = isPassing 
+	? bnToIntBalance(nayVotes.add(threshold)) || 1
+	: bnToIntBalance(ayeVotes.add(threshold)) || 1;
 	const thresholdPercent = isPassing
 		? (1-thresholdNumber/totalVotesNumberDivider)*100
 		: thresholdNumber / totalVotesNumberDivider*100;

--- a/front-end/src/ui-components/VoteProgress.tsx
+++ b/front-end/src/ui-components/VoteProgress.tsx
@@ -29,9 +29,9 @@ const VoteProgress = ({ ayeVotes, className, isPassing, nayVotes, threshold }: P
 	const thresholdNumber = bnToIntBalance(threshold);
 	const ayeVotesNumber = bnToIntBalance(ayeVotes);
 	const totalVotesNumber = bnToIntBalance(ayeVotes.add(nayVotes));
-	const totalVotesNumberDivider = isPassing 
-	? bnToIntBalance(ayeVotes.add(threshold))
-	: bnToIntBalance(nayVotes.add(threshold)) || 1;
+	const totalVotesNumberDivider = isPassing
+		? bnToIntBalance(ayeVotes.add(threshold))
+		: bnToIntBalance(nayVotes.add(threshold)) || 1;
 	const thresholdPercent = isPassing
 		? (1-thresholdNumber/totalVotesNumberDivider)*100
 		: thresholdNumber / totalVotesNumberDivider*100;


### PR DESCRIPTION
The threshold should be calculated taking the new amount needed into account:
- if it's passing, the new amount is aye + neededNays
- if it's failing, the new amount is nay+ neededAyes

So far, the new amount was aye + nay, which does not take the needed votes into account.

Example:
![image](https://user-images.githubusercontent.com/33178835/83331291-87c6c900-a295-11ea-9b10-9081f92e7862.png)

isPassing = false
Threshold = ~92.9K

ThresholdPercent = 92.9K / (92.9K + 9.8K) * 100 ->  90.4%