### PR TITLE
Fix icon for failing referendum

### DIFF
--- a/front-end/src/ui-components/PassingInfo.tsx
+++ b/front-end/src/ui-components/PassingInfo.tsx
@@ -16,13 +16,13 @@ const PassingInfo = ({ className, isPassing }:Props ) => {
 	const NO_INFO_TEXT = '-';
 
 	let text = '';
-	let iconName : 'check circle outline' | 'check circle outline' | null = null;
+	let iconName : 'check circle outline' | 'times circle outline' | null = null;
 
 	if (isPassing === null){
 		text = NO_INFO_TEXT;
 	} else {
 		text = isPassing ? 'Passing' : 'Failing';
-		iconName = isPassing ? 'check circle outline' : 'check circle outline';
+		iconName = isPassing ? 'check circle outline' : 'times circle outline';
 	}
 	return (
 		<div className={`${className} ${text === NO_INFO_TEXT ? null : text.toLowerCase()}`}>


### PR DESCRIPTION
We're currently showing a checkmark:
<img width="499" alt="Screenshot 2020-06-08 at 09 53 04" src="https://user-images.githubusercontent.com/7072141/84006141-891b8400-a96e-11ea-8143-bff72391a4e7.png">

Replaced with times icon:
<img width="497" alt="Screenshot 2020-06-08 at 09 56 38" src="https://user-images.githubusercontent.com/7072141/84006153-8c167480-a96e-11ea-94ea-81b558e57bf4.png">
