### PR TITLE
Add production connection db

### DIFF
--- a/auth-server/knexfile.ts
+++ b/auth-server/knexfile.ts
@@ -2,24 +2,31 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 import dotenv from 'dotenv';
-
 import { Config } from 'src/types';
 
 dotenv.config();
 
 // e.g. 'postgres://postgres:postgres@localhost:5431/governance-auth'
 const devConnectionUrl = process.env.DATABASE_URL;
+const prodConnectionUrl = process.env.DATABASE_URL;
 const testConnectionUrl = process.env.TEST_DATABASE_URL;
 
 const config: Config = {
-	'development': {
+	development: {
 		client: 'postgresql',
 		connection: devConnectionUrl,
 		migrations: {
 			directory: `${__dirname}/migrations`
 		}
 	},
-	'test': {
+	production: {
+		client: 'postgresql',
+		connection: prodConnectionUrl,
+		migrations: {
+			directory: `${__dirname}/migrations`
+		}
+	},
+	test: {
 		client: 'postgresql',
 		connection: testConnectionUrl,
 		migrations: {


### PR DESCRIPTION
Fix
```bash
yarn start      
yarn run v1.22.4
$ yarn tsc && yarn migrate && node build/src/index.js
$ tsc
$ knex migrate:latest
Requiring external module ts-node/register
Error: DB Connection not provided for env production
    at Object.<anonymous> (/home/thib/github/paritytech/polkassembly/auth-server/knexfile.ts:42:8)
    at Module._compile (internal/modules/cjs/loader.js:955:30)
    at Module.m._compile (/home/thib/github/paritytech/polkassembly/auth-server/node_modules/ts-node/src/index.ts:858:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:991:10)
    at Object.require.extensions.<computed> [as .ts] (/home/thib/github/paritytech/polkassembly/auth-server/node_modules/ts-node/src/index.ts:861:12)
    at Module.load (internal/modules/cjs/loader.js:811:32)
    at Function.Module._load (internal/modules/cjs/loader.js:723:14)
    at Module.require (internal/modules/cjs/loader.js:848:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at openKnexfile (/home/thib/github/paritytech/polkassembly/auth-server/node_modules/knex/bin/cli.js:26:16)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```