### PR TITLE
Use account component in preimage arguments

### DIFF
--- a/front-end/src/components/Post/PostGovernanceInfo/PostMotionInfo.tsx
+++ b/front-end/src/components/Post/PostGovernanceInfo/PostMotionInfo.tsx
@@ -91,8 +91,9 @@ const ProposalInfo = ({ preimage } : {preimage?: OnchainLinkMotionPreimageFragme
 							? <>
 								<h6>Arguments</h6>
 								{preimageArguments.map((element, index) => {
-									return <div className={element.name !== 'account' ? 'methodArguments' : ''} key={index}>
-										{element.name === 'account'
+									const isAccountArgument = element.name === 'account';
+									return <div className={isAccountArgument ? '' : 'methodArguments'} key={index}>
+										{isAccountArgument
 											? <AddressComponent address={element.value} key={index}/>
 											: <span key={index}>{element.name}: {element.value}</span>
 										}

--- a/front-end/src/components/Post/PostGovernanceInfo/PostMotionInfo.tsx
+++ b/front-end/src/components/Post/PostGovernanceInfo/PostMotionInfo.tsx
@@ -91,8 +91,11 @@ const ProposalInfo = ({ preimage } : {preimage?: OnchainLinkMotionPreimageFragme
 							? <>
 								<h6>Arguments</h6>
 								{preimageArguments.map((element, index) => {
-									return <div className={'methodArguments'} key={index}>
-										<span key={index}>{element.name}: {element.value}</span>
+									return <div className={element.name !== 'account' ? 'methodArguments' : ''} key={index}>
+										{element.name === 'account'
+											? <AddressComponent address={element.value} key={index}/>
+											: <span key={index}>{element.name}: {element.value}</span>
+										}
 									</div>;
 								})}
 							</>

--- a/front-end/src/components/Post/PostGovernanceInfo/PostProposalInfo.tsx
+++ b/front-end/src/components/Post/PostGovernanceInfo/PostProposalInfo.tsx
@@ -53,8 +53,9 @@ const PostProposalInfo = ({ onchainLink }: Props) => {
 							? <>
 								<h6>Arguments</h6>
 								{preimageArguments.map((element, index) => {
-									return <div className={element.name !== 'account' ? 'methodArguments' : ''} key={index}>
-										{element.name === 'account'
+									const isAccountArgument = element.name === 'account';
+									return <div className={isAccountArgument ? '' : 'methodArguments'} key={index}>
+										{isAccountArgument
 											? <AddressComponent address={element.value} key={index}/>
 											: <span key={index}>{element.name}: {element.value}</span>
 										}

--- a/front-end/src/components/Post/PostGovernanceInfo/PostProposalInfo.tsx
+++ b/front-end/src/components/Post/PostGovernanceInfo/PostProposalInfo.tsx
@@ -53,8 +53,11 @@ const PostProposalInfo = ({ onchainLink }: Props) => {
 							? <>
 								<h6>Arguments</h6>
 								{preimageArguments.map((element, index) => {
-									return <div className={'methodArguments'} key={index}>
-										<span key={index}>{element.name}: {element.value}</span>
+									return <div className={element.name !== 'account' ? 'methodArguments' : ''} key={index}>
+										{element.name === 'account'
+											? <AddressComponent address={element.value} key={index}/>
+											: <span key={index}>{element.name}: {element.value}</span>
+										}
 									</div>;
 								})}
 							</>

--- a/front-end/src/components/Post/PostGovernanceInfo/PostReferendumInfo.tsx
+++ b/front-end/src/components/Post/PostGovernanceInfo/PostReferendumInfo.tsx
@@ -76,8 +76,11 @@ const PostReferendumInfo = ({ onchainLink }: Props) => {
 							? <>
 								<h6>Arguments</h6>
 								{preimageArguments.map((element, index) => {
-									return <div className={'methodArguments'} key={index}>
-										<span key={index}>{element.name}: {element.value}</span>
+									return <div className={element.name !== 'account' ? 'methodArguments' : ''} key={index}>
+										{element.name === 'account'
+											? <AddressComponent address={element.value} key={index}/>
+											: <span key={index}>{element.name}: {element.value}</span>
+										}
 									</div>;
 								})}
 							</>

--- a/front-end/src/components/Post/PostGovernanceInfo/PostReferendumInfo.tsx
+++ b/front-end/src/components/Post/PostGovernanceInfo/PostReferendumInfo.tsx
@@ -76,8 +76,9 @@ const PostReferendumInfo = ({ onchainLink }: Props) => {
 							? <>
 								<h6>Arguments</h6>
 								{preimageArguments.map((element, index) => {
-									return <div className={element.name !== 'account' ? 'methodArguments' : ''} key={index}>
-										{element.name === 'account'
+									const isAccountArgument = element.name === 'account';
+									return <div className={isAccountArgument ? '' : 'methodArguments'} key={index}>
+										{isAccountArgument
 											? <AddressComponent address={element.value} key={index}/>
 											: <span key={index}>{element.name}: {element.value}</span>
 										}


### PR DESCRIPTION
Closes #851

<img width="794" alt="Screenshot 2020-06-08 at 15 25 35" src="https://user-images.githubusercontent.com/7072141/84036683-d531ed00-a99d-11ea-8c30-18e658511b95.png">

Applying `methodArguments` class conditionally is not very nice, but otherwise `overflow` would clip the left edge of the address identicon.