### PR TITLE
Remove setter for HASURA_CHAIN_DB_REMOTE_SCHEMA

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,7 +192,6 @@ dockerize-node-watcher:
       --set hasura.config.HASURA_GRAPHQL_DATABASE_URL=${HASURA_GRAPHQL_DATABASE_URL}
       --set hasura.config.HASURA_POST_SUBSCRIPTION_SECRET=${HASURA_POST_SUBSCRIPTION_SECRET}
       --set hasura.config.HASURA_EVENT_SECRET=${HASURA_EVENT_SECRET}
-      --set hasura.config.HASURA_CHAIN_DB_REMOTE_SCHEMA=${HASURA_CHAIN_DB_REMOTE_SCHEMA}
       --set hasura.secret.HASURA_GRAPHQL_JWT_SECRET=${HASURA_GRAPHQL_JWT_SECRET}
       --set authServer.config.DATABASE_URL=${DATABASE_URL}
       --set authServer.config.HASURA_EVENT_SECRET=${HASURA_EVENT_SECRET}


### PR DESCRIPTION
This variable is now set in https://github.com/paritytech/polkassembly/blob/master/kubernetes/polkassembly/values.yaml#L62

It can then be deleted from Gitlab.