### PR TITLE
Print public env and warn about unset ones

### DIFF
--- a/auth-server/src/index.ts
+++ b/auth-server/src/index.ts
@@ -15,6 +15,7 @@ import resolvers from './resolvers';
 import routes from './routes';
 import schema from './schema';
 import { Context } from './types';
+import verifyEnvVariables from './utils/verifyEnvVariables';
 
 dotenv.config();
 
@@ -72,6 +73,8 @@ app.use(expressValidator());
 server.applyMiddleware({ app, path: '/auth/graphql' });
 
 app.use(routes);
+
+verifyEnvVariables();
 
 /**
  * Start Express server.

--- a/auth-server/src/utils/verifyEnvVariables.ts
+++ b/auth-server/src/utils/verifyEnvVariables.ts
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 @paritytech/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import chalk from 'chalk';
+
+export default function verifyEnvVariables (): void {
+	// Don't log the follwing on purpose
+	// JWT_PRIVATE_KEY_TEST
+	// TEST_DATABASE_URL
+	// JWT_KEY_PASSPHRASE_TEST
+	// JWT_PUBLIC_KEY_TEST
+
+	const publics = [
+		'NODE_ENV',
+		'PORT',
+		'PROPOSAL_BOT_USER_ID',
+		'DOMAIN_PROTOCOL',
+		'DOMAIN_NAME'
+	];
+	const secrets = [
+		'JWT_PUBLIC_KEY', // seting it as a secret because it's printing too many lines otherwise
+		'JWT_PRIVATE_KEY',
+		'JWT_KEY_PASSPHRASE',
+		'REDIS_URL',
+		'DATABASE_URL',
+		'HASURA_EVENT_SECRET',
+		'SENDGRID_API_KEY'
+	];
+
+	publics.forEach(env => {
+		const value = process.env[env];
+		if (!value) {
+			console.error(chalk.red(`✖︎ Environment variable ${env} not set.`));
+		} else {
+			console.log(chalk.green('✓'), `${env} set to ${value}`);
+		}
+	});
+
+	secrets.forEach(secret => {
+		if (!process.env[secret]) {
+			console.error(chalk.red(`✖︎ Environment (secret) variable ${secret} not set.`));
+		}
+	});
+
+	console.log('------------------------------------------');
+}

--- a/auth-server/src/utils/verifyEnvVariables.ts
+++ b/auth-server/src/utils/verifyEnvVariables.ts
@@ -5,7 +5,7 @@
 import chalk from 'chalk';
 
 export default function verifyEnvVariables (): void {
-	// Don't log the follwing on purpose
+	// Don't log the following on purpose
 	// JWT_PRIVATE_KEY_TEST
 	// TEST_DATABASE_URL
 	// JWT_KEY_PASSPHRASE_TEST
@@ -19,7 +19,7 @@ export default function verifyEnvVariables (): void {
 		'DOMAIN_NAME'
 	];
 	const secrets = [
-		'JWT_PUBLIC_KEY', // seting it as a secret because it's printing too many lines otherwise
+		'JWT_PUBLIC_KEY', // setting it as a secret because it's spamming otherwise
 		'JWT_PRIVATE_KEY',
 		'JWT_KEY_PASSPHRASE',
 		'REDIS_URL',


### PR DESCRIPTION
Will help to debug the move to Polkadot and variable shuffling.

This prints something like:
```bash
yarn run v1.22.4
$ yarn tsc && yarn migrate && node build/src/index.js
$ tsc
$ knex migrate:latest
Requiring external module ts-node/register
Already up to date
✓ NODE_ENV set to development
✓ PORT set to 8010
✓ PROPOSAL_BOT_USER_ID set to 38
✓ DOMAIN_PROTOCOL set to https://
✓ DOMAIN_NAME set to test.polkassembly.io
------------------------------------------
✓ App is running at http://localhost:8010 in development mode
  Press CTRL-C to stop

```