### PR TITLE
Remove hack seconding

### DIFF
--- a/front-end/src/components/Post/GovernanceSideBar/Proposals/SecondProposal.tsx
+++ b/front-end/src/components/Post/GovernanceSideBar/Proposals/SecondProposal.tsx
@@ -43,12 +43,7 @@ const SecondProposal = ({ className, proposalId, address, accounts, onAccountCha
 
 		setLoadingStatus({ isLoading: true, message: 'Waiting for signature' });
 
-		const params = api.tx.democracy.second.meta.args.length === 2
-			? [proposalId, seconds]
-			: [proposalId];
-
-		// eslint-disable-next-line no-extra-parens
-		const second = (api.tx.democracy as any).second(...params);
+		const second = api.tx.democracy.second(proposalId, seconds);
 
 		second.signAndSend(address, ({ status }: any) => {
 			if (status.isInBlock) {


### PR DESCRIPTION
Removes a hack introduced (with https://github.com/paritytech/polkassembly/pull/808) before a runtime upgrade as Kusama and Polkadot had different behaviours.

I was able to second a real proposal.