### PR TITLE
Remove no-extra-parens from eslint rules

### DIFF
--- a/auth-server/.eslintrc.json
+++ b/auth-server/.eslintrc.json
@@ -34,7 +34,6 @@
         "comma-dangle": ["error", "never"],
         "header/header": [2, "../header.js"],
         "indent": ["error", "tab"],
-        "no-extra-parens": ["error", "all", { "returnAssign": false }],
         "no-multiple-empty-lines": ["error", {"max": 1}],
         "no-tabs": ["error", { "allowIndentationTabs": true }],
         "no-trailing-spaces": ["warn"],

--- a/chain-db-watcher/.eslintrc.json
+++ b/chain-db-watcher/.eslintrc.json
@@ -33,7 +33,6 @@
     "comma-dangle": ["error", "never"],
     "header/header": [2, "../header.js"],
     "indent": ["error", "tab"],
-    "no-extra-parens": ["error", "all", { "returnAssign": false }],
     "no-multiple-empty-lines": ["error", {"max": 1}],
     "no-tabs": ["error", { "allowIndentationTabs": true }],
     "no-trailing-spaces": ["warn"],

--- a/front-end/.eslintrc.json
+++ b/front-end/.eslintrc.json
@@ -40,7 +40,6 @@
         "comma-dangle": ["error", "never"],
         "header/header": [2, "../header.js"],
         "indent": ["error", "tab"],
-        "no-extra-parens": ["error", "all", { "returnAssign": false }],
         "no-multiple-empty-lines": ["error", {"max": 1}],
         "no-tabs": ["error", { "allowIndentationTabs": true }],
         "no-trailing-spaces": ["warn"],

--- a/front-end/src/components/Post/GovernanceSideBar/Proposals/SecondProposal.tsx
+++ b/front-end/src/components/Post/GovernanceSideBar/Proposals/SecondProposal.tsx
@@ -47,7 +47,6 @@ const SecondProposal = ({ className, proposalId, address, accounts, onAccountCha
 			? [proposalId, seconds]
 			: [proposalId];
 
-		// eslint-disable-next-line no-extra-parens
 		const second = (api.tx.democracy as any).second(...params);
 
 		second.signAndSend(address, ({ status }: any) => {

--- a/front-end/src/components/Post/GovernanceSideBar/index.tsx
+++ b/front-end/src/components/Post/GovernanceSideBar/index.tsx
@@ -127,7 +127,6 @@ const GovenanceSideBar = ({ className, isMotion, isProposal, isReferendum, oncha
 								{(onchainId || onchainId === 0) &&
 									<ReferendumVoteInfo
 										referendumId={onchainId}
-										// eslint-disable-next-line no-extra-parens
 										threshold={((onchainLink as OnchainLinkReferendumFragment).onchain_referendum[0]?.voteThreshold) as VoteThreshold}
 									/>
 								}

--- a/front-end/src/components/Post/Post.tsx
+++ b/front-end/src/components/Post/Post.tsx
@@ -117,7 +117,6 @@ const Post = ( { className, data, isMotion = false, isProposal = false, isRefere
 
 	const isDiscussion = (post: TreasuryProposalPostFragment | MotionPostFragment | ProposalPostFragment | DiscussionPostFragment | ReferendumPostFragment): post is DiscussionPostFragment => {
 		if (!isReferendum && !isProposal && !isMotion && !isTreasuryProposal) {
-			// eslint-disable-next-line no-extra-parens
 			return (post as DiscussionPostFragment) !== undefined;
 		}
 

--- a/front-end/src/hooks/useRedirectGovernancePost.ts
+++ b/front-end/src/hooks/useRedirectGovernancePost.ts
@@ -1,7 +1,6 @@
 // Copyright 2019-2020 @paritytech/polkassembly authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
-/* eslint-disable no-extra-parens */
 
 import { useEffect } from 'react';
 import { OnchainLinkDiscussionFragment,

--- a/health-monitor/.eslintrc.json
+++ b/health-monitor/.eslintrc.json
@@ -34,7 +34,6 @@
         "comma-dangle": ["error", "never"],
         "header/header": [2, "../header.js"],
         "indent": ["error", "tab"],
-        "no-extra-parens": ["error", "all", { "returnAssign": false }],
         "no-multiple-empty-lines": ["error", {"max": 1}],
         "no-tabs": ["error", { "allowIndentationTabs": true }],
         "no-trailing-spaces": ["warn"],

--- a/util/.eslintrc.json
+++ b/util/.eslintrc.json
@@ -27,7 +27,6 @@
         "comma-dangle": ["error", "never"],
         "header/header": [2, "../header.js"],
         "indent": ["error", "tab"],
-        "no-extra-parens": ["error", "all", { "returnAssign": false }],
         "no-multiple-empty-lines": ["error", {"max": 1}],
         "no-tabs": ["error", { "allowIndentationTabs": true }],
         "no-trailing-spaces": ["warn"],


### PR DESCRIPTION
This was more annoying than helping considering the amount of exceptions we had.