### PR TITLE
Mde-preview overlap fix when displaying code

### DIFF
--- a/front-end/src/components/Comment/Comment.tsx
+++ b/front-end/src/components/Comment/Comment.tsx
@@ -108,7 +108,7 @@ export default styled(Comment)`
 		border-radius: 3px;
 		box-shadow: box_shadow_card;
 		margin-bottom: 1rem;
-		width: 100%;
+		width: calc(100% - 60px);
 		word-break: break-word;
 
 		@media only screen and (max-width: 576px) {

--- a/front-end/src/components/Post/PostCommentForm.tsx
+++ b/front-end/src/components/Post/PostCommentForm.tsx
@@ -129,7 +129,7 @@ export default styled(PostCommentForm)`
 		padding: 1rem;
 		border-radius: 3px;
 		box-shadow: box_shadow_card;
-		width: 100%;
+		width: calc(100% - 60px);
 	}
 
 	.button-container {

--- a/front-end/src/ui-components/GlobalStyle.tsx
+++ b/front-end/src/ui-components/GlobalStyle.tsx
@@ -27,6 +27,7 @@ export const GlobalStyle = createGlobalStyle`
         display: inline-block;
         max-width: 100%;
         white-space: pre-wrap;
+        background-color: grey_light;
     }
 
     code {

--- a/front-end/src/ui-components/Markdown.tsx
+++ b/front-end/src/ui-components/Markdown.tsx
@@ -86,16 +86,23 @@ export default styled(Markdown)`
 			margin: 2rem 0;
 		}
 
+		pre {
+			background-color: grey_light;
+		}
+
 		code {
 			padding: 0.4rem;
 			margin: 0;
 			font-size: sm;
-			background-color: rgba(0, 0, 0, 0.04);
 			border-radius: 3px;
 			color: black_text;
 			&::before, &::after {
 			letter-spacing: -0.2em;
 			}
+		}
+
+		pre>code {
+			white-space: pre-wrap;
 		}
 	}
 

--- a/front-end/src/ui-components/Markdown.tsx
+++ b/front-end/src/ui-components/Markdown.tsx
@@ -88,21 +88,20 @@ export default styled(Markdown)`
 
 		pre {
 			background-color: grey_light;
+			padding: 1.6rem;
+			overflow: auto;
+			border-radius: 0.3rem;
 		}
 
 		code {
-			padding: 0.4rem;
 			margin: 0;
 			font-size: sm;
 			border-radius: 3px;
 			color: black_text;
+			white-space: pre;
 			&::before, &::after {
-			letter-spacing: -0.2em;
+				letter-spacing: -0.2em;
 			}
-		}
-
-		pre>code {
-			white-space: pre-wrap;
 		}
 	}
 


### PR DESCRIPTION
Closes #891

Overlap only happened when previewing code afaic. Fixed mde text-editor code preview formatting and changed comment box max-width.

<img width="907" alt="Screenshot 2020-06-12 at 13 07 46" src="https://user-images.githubusercontent.com/7072141/84497042-55ae6180-acae-11ea-9cf2-2d07ec83c433.png">

