### PR TITLE
fix: port lable more the 15 chars

### DIFF
--- a/kubernetes/node-watcher/templates/chain-db-open-server-service.yaml
+++ b/kubernetes/node-watcher/templates/chain-db-open-server-service.yaml
@@ -6,8 +6,7 @@ metadata:
     {{- include "node-watcher.chainDbOpenServer.labels" . | nindent 4 }}
 spec:
   ports:
-  - name: {{ .Values.chainDbOpenServer.name }}-service
-    port: {{ .Values.chainDbOpenServer.service.port }}
+  - port: {{ .Values.chainDbOpenServer.service.port }}
     protocol: TCP
   selector:
     {{- include "node-watcher.chainDbOpenServer.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
`chain-db-open-server-port` exceeded the max length of a label name in k8s. hence labeling a `port` with a name is optional i decided to remove it entirely. 