### PR TITLE
Add unique keys for polls and reactions

### DIFF
--- a/hasura/hasura-migrations/migrations/1592400318046_alter_table_public_poll_votes_add_unique_poll_id_user_id/down.yaml
+++ b/hasura/hasura-migrations/migrations/1592400318046_alter_table_public_poll_votes_add_unique_poll_id_user_id/down.yaml
@@ -1,0 +1,5 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: alter table "public"."poll_votes" drop constraint "poll_votes_poll_id_user_id_key";
+  type: run_sql

--- a/hasura/hasura-migrations/migrations/1592400318046_alter_table_public_poll_votes_add_unique_poll_id_user_id/up.yaml
+++ b/hasura/hasura-migrations/migrations/1592400318046_alter_table_public_poll_votes_add_unique_poll_id_user_id/up.yaml
@@ -1,0 +1,6 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: alter table "public"."poll_votes" add constraint "poll_votes_poll_id_user_id_key"
+      unique ("poll_id", "user_id");
+  type: run_sql

--- a/hasura/hasura-migrations/migrations/1592400359607_alter_table_public_comment_reactions_add_unique_comment_id_user_id_reaction/down.yaml
+++ b/hasura/hasura-migrations/migrations/1592400359607_alter_table_public_comment_reactions_add_unique_comment_id_user_id_reaction/down.yaml
@@ -1,0 +1,5 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: alter table "public"."comment_reactions" drop constraint "comment_reactions_comment_id_user_id_reaction_key";
+  type: run_sql

--- a/hasura/hasura-migrations/migrations/1592400359607_alter_table_public_comment_reactions_add_unique_comment_id_user_id_reaction/up.yaml
+++ b/hasura/hasura-migrations/migrations/1592400359607_alter_table_public_comment_reactions_add_unique_comment_id_user_id_reaction/up.yaml
@@ -1,0 +1,6 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: alter table "public"."comment_reactions" add constraint "comment_reactions_comment_id_user_id_reaction_key"
+      unique ("comment_id", "user_id", "reaction");
+  type: run_sql

--- a/hasura/hasura-migrations/migrations/1592400398659_alter_table_public_post_reactions_add_unique_post_id_user_id_reaction/down.yaml
+++ b/hasura/hasura-migrations/migrations/1592400398659_alter_table_public_post_reactions_add_unique_post_id_user_id_reaction/down.yaml
@@ -1,0 +1,5 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: alter table "public"."post_reactions" drop constraint "post_reactions_post_id_user_id_reaction_key";
+  type: run_sql

--- a/hasura/hasura-migrations/migrations/1592400398659_alter_table_public_post_reactions_add_unique_post_id_user_id_reaction/up.yaml
+++ b/hasura/hasura-migrations/migrations/1592400398659_alter_table_public_post_reactions_add_unique_post_id_user_id_reaction/up.yaml
@@ -1,0 +1,6 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: alter table "public"."post_reactions" add constraint "post_reactions_post_id_user_id_reaction_key"
+      unique ("post_id", "user_id", "reaction");
+  type: run_sql


### PR DESCRIPTION
closes #779 

prevent combination
- user, vote, poll id from voting >1x
- user, reaction, comment id from reacting >1x
- user, reaction, post id from reacting >1x

I was able to test this specifically, getting for instance on post:
```
{
  "errors": [
    {
      "extensions": {
        "path": "$.selectionSet.insert_post_reactions.args.objects",
        "code": "constraint-violation"
      },
      "message": "Uniqueness violation. duplicate key value violates unique constraint \"post_reactions_post_id_user_id_reaction_key\""
    }
  ]
}
```