### PR TITLE
Switching LRU mode in redis for keys eviction on max memory usage

### DIFF
--- a/kubernetes/redis/values/dashboards-cluster-1.yaml
+++ b/kubernetes/redis/values/dashboards-cluster-1.yaml
@@ -5,3 +5,7 @@ usePassword: true
 
 metrics:
   enabled: false
+
+master:
+  extraFlags:
+    - --maxmemory-policy allkeys-lru

--- a/kubernetes/redis/values/parity-prod.yaml
+++ b/kubernetes/redis/values/parity-prod.yaml
@@ -5,3 +5,7 @@ usePassword: true
 
 metrics:
   enabled: false
+
+master:
+  extraFlags:
+    - --maxmemory-policy allkeys-lru

--- a/kubernetes/redis/values/polkadot-prod.yaml
+++ b/kubernetes/redis/values/polkadot-prod.yaml
@@ -5,3 +5,7 @@ usePassword: true
 
 metrics:
   enabled: false
+
+master:
+  extraFlags:
+    - --maxmemory-policy allkeys-lru


### PR DESCRIPTION
Closes: https://github.com/paritytech/polkassembly/issues/600

As per https://redis.io/topics/lru-cache setting --maxmemory-policy will evict keys when full memory