### PR TITLE
Support any address crypto

### DIFF
--- a/auth-server/src/utils/verifySignature.ts
+++ b/auth-server/src/utils/verifySignature.ts
@@ -2,12 +2,12 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { schnorrkelVerify } from '@polkadot/util-crypto';
+import { signatureVerify } from '@polkadot/util-crypto';
 
 import getPublicKey from './getPublicKey';
 
 export default (message: string, address: string, signature: string): boolean => {
 	const publicKey = getPublicKey(address);
 
-	return schnorrkelVerify(message, signature, publicKey);
+	return signatureVerify(message, signature, publicKey).isValid;
 };


### PR DESCRIPTION
closes #1033 

I could only test with ed25519 und sr25519 because the extension doesn't support the other types. But using the generic function helps to be future proof.

Note, to be able to end up with an "ed" account in the extension you need to use https://polkadot.js.org/apps/ and create an account with ed25519 (click advanced to change the crypto type), then export the JSON, then import it in the extension.