### PR TITLE
make use of  docker:git  (latest)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,7 @@ lint-chain-db-watcher:
 .build_and_push:                   &build_and_push
   tags:
     - kubernetes-parity-build
-  image:                           docker:18-git
+  image:                           docker:git
   retry:
     max:                           2
     when:


### PR DESCRIPTION
version 18 was made sticky a while ago as a (hot)fix, and should be removed 