### PR TITLE
CI: remove squash and fix buildah push

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,13 +116,13 @@ lint-chain-db-watcher:
     - echo "$Docker_Hub_Pass_Parity" | buildah login -u "$Docker_Hub_User_Parity" --password-stdin docker.io
     # do: docker build
     - eval "buildah bud
-        --squash
         --format=docker
         --cache-from $DOCKER_IMAGE:latest 
         -t" "$DOCKER_IMAGE:$DOCKER_TAG" "
         -t $DOCKER_IMAGE:latest" "$BUILD_ARGS" "$POD_NAME"
     # do: docker push
-    - buildah push --format=v2s2 "$DOCKER_IMAGE:latest" "$DOCKER_IMAGE:$DOCKER_TAG"
+    - buildah push --format=v2s2 "$DOCKER_IMAGE:latest"
+    - buildah push --format=v2s2 "$DOCKER_IMAGE:$DOCKER_TAG"
 
 dockerize:kusama-staging-front-end:
   stage:                           dockerize


### PR DESCRIPTION
- fixes buildah bush, apparently it couldn't push several tags within one command
- removes --squash, is wins in the final image size, but makes it one layer, hence unable to reuse the base image, looses in download time.
