### PR TITLE
Wrapping sign message with <Bytes>for polkadot js extension

### DIFF
--- a/auth-server/src/resolvers/mutation/addressLinkStart.ts
+++ b/auth-server/src/resolvers/mutation/addressLinkStart.ts
@@ -34,7 +34,7 @@ export default async (parent: void, { network, address }: AddressLinkStartArgs, 
 		.insert({
 			address,
 			network,
-			sign_message: uuid(),
+			sign_message: `<Bytes>${uuid()}</Bytes>`,
 			user_id: user.id,
 			verified: false
 		});

--- a/auth-server/src/services/auth.ts
+++ b/auth-server/src/services/auth.ts
@@ -240,7 +240,7 @@ export default class AuthService {
 	}
 
 	public async AddressLoginStart (address: string): Promise<string> {
-		const signMessage = uuid();
+		const signMessage = `<Bytes>${uuid()}</Bytes>`;
 
 		await redisSetex(getAddressLoginKey(address), ADDRESS_LOGIN_TTL, signMessage);
 
@@ -295,7 +295,7 @@ export default class AuthService {
 			throw new ForbiddenError(messages.ADDRESS_SIGNUP_ALREADY_EXISTS);
 		}
 
-		const signMessage = uuid();
+		const signMessage = `<Bytes>${uuid()}</Bytes>`;
 
 		await redisSetex(getAddressSignupKey(address), ADDRESS_LOGIN_TTL, signMessage);
 
@@ -615,7 +615,7 @@ export default class AuthService {
 			throw new ForbiddenError(messages.ADDRESS_NOT_FOUND);
 		}
 
-		const signMessage = uuid();
+		const signMessage = `<Bytes>${uuid()}</Bytes>`;
 
 		await redisSetex(getSetCredentialsKey(address), ADDRESS_LOGIN_TTL, signMessage);
 


### PR DESCRIPTION
Due to change in polkadot js extension https://github.com/polkadot-js/extension/pull/743/ wrapping all signMessage in <Bytes></Bytes>