### PR TITLE
migrate ingress objects to new ingress controller

### DIFF
--- a/kubernetes/polkassembly/values-dashboards-cluster-1.yaml
+++ b/kubernetes/polkassembly/values-dashboards-cluster-1.yaml
@@ -13,12 +13,17 @@ frontend:
   ingress:
     enabled: true
     annotations:
-      traefik.ingress.kubernetes.io/redirect-entry-point: https
-
+      kubernetes.io/ingress.class: traefik-external
+      traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+      cert-manager.io/cluster-issuer: letsencrypt-http01
+      traefik.ingress.kubernetes.io/router.tls: "true"
     hosts:
       - host: test.polkassembly.io
         paths: []
-    tls: []
+    tls:
+      - hosts:
+        - test.polkassembly.io
+        secretName: test.polkassembly.io
 
 authServer:
   config:

--- a/kubernetes/polkassembly/values-parity-prod.yaml
+++ b/kubernetes/polkassembly/values-parity-prod.yaml
@@ -13,13 +13,20 @@ frontend:
   ingress:
     enabled: true
     annotations:
-      traefik.ingress.kubernetes.io/redirect-entry-point: https
+      kubernetes.io/ingress.class: traefik-external
+      traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+      cert-manager.io/cluster-issuer: letsencrypt-http01
+      traefik.ingress.kubernetes.io/router.tls: "true"
     hosts:
       - host: kusama.polkassembly.io
         path: /
       - host: polkassembly.io
         path: /
-    tls: []
+    tls:
+      - hosts:
+        - polkassembly.io
+        - kusama.polkassembly.io
+        secretName: polkassembly.io
 
 authServer:
   config:

--- a/kubernetes/polkassembly/values-polkadot-prod.yaml
+++ b/kubernetes/polkassembly/values-polkadot-prod.yaml
@@ -13,11 +13,17 @@ frontend:
   ingress:
     enabled: true
     annotations:
-      traefik.ingress.kubernetes.io/redirect-entry-point: https
+      kubernetes.io/ingress.class: traefik-external
+      traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+      cert-manager.io/cluster-issuer: letsencrypt-http01
+      traefik.ingress.kubernetes.io/router.tls: "true"
     hosts:
       - host: polkadot.polkassembly.io
         path: /
-    tls: []
+    tls:
+      - hosts:
+        - polkadot.polkassembly.io
+        secretName: polkadot.polkassembly.io
 
 authServer:
   config:


### PR DESCRIPTION
Regarding the [issue #872](https://github.com/paritytech/devops/issues/872), helm chart needs to be changed and applied by the CI to migrate the ingress objects to the new controller.

The following DNS records must be changed to point to `traefik-external.parity-prod.parity.io` before merging the PR:
- polkassembly.io
- kusama.polkassembly.io
- polkadot.polkassembly.io

 **This PR must be merged by the DevOps once it's approved!**
 **Changing the DNS name might cause ~5minutes downtime. Please propose a time that this change could be applied.**