### PR TITLE
Replace README with a pointer to Premiurly's fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
-# Polkassembly - https://polkassembly.io
-The place to discuss and vote on Kusama and Polkadot governance.
+Polkassembly has a new home at https://github.com/Premiurly/polkassembly.
 
-Polkassembly is a platform for anyone to discover and participate in Polkadot and Kusama governance. You can browse proposals made on chain, discuss with the community and vote directly from the website using a browser extension. Proposal authors are the only one able to edit the proposal post and description. You don't have to, but adding an email may help to recover your account, also you can get notifications for discussions of interest or when a new proposal appears on-chain.
-
----
-
-This repo hosts 
-- auth-server: the nodeJS backend and its db responsible for user authentication.
-- hasura: the docker that host the discussion db as well as the graphQL server that exposes the db to the Polkassembly application.
-- chain-db-watcher: a nodeJS service creating or updating the discussion db as soon as governance events happen on-chain.
-- front-end: the React front-end application available on https://polkassembly.io.
-
-`launch.sh` is a script that helps (first stop and then) launch the dockers and servers in the right order as well as applying the migrations for the different db.
+Please direct all your questions, issues and pull requests there.


### PR DESCRIPTION
Since Premiurly forked the codebase instead of transferring it — we can only have a human-readable redirect here.

So let's merge this, and I'll archive our copy of the repo